### PR TITLE
assemblyscript: fix ignored files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,4 @@
 /benchmark/
 /golang/
 /cmd/
-/assemblyscript/
+/c/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "karmem",
   "description": "Karmem: fast serialization format.",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "test": "node assemblyscript/tests",


### PR DESCRIPTION
Before that change, `/assemblyscript/` folder was ignored.

Fixes: https://github.com/inkeliz/karmem/issues/5