### PR TITLE
kmgen,swift: [swift] big performance optimization for Swift 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,38 +163,38 @@ Using similar schema with Flatbuffers and Karmem. Karmem is almost 10 times fast
 **Native (MacOS/ARM64 - M1):**
 
 ```
-name               flatbuffers/op    karmem/op    delta
-EncodeObjectAPI-8    1.46ms ± 0%    0.32ms ± 0%   -78.22%  (p=0.008 n=5+5)
-DecodeObjectAPI-8    2.16ms ± 0%    0.15ms ± 0%   -93.14%  (p=0.008 n=5+5)
-DecodeSumVec3-8       887µs ± 1%      99µs ± 1%   -88.86%  (p=0.008 n=5+5)
+name               old time/op    new time/op    delta
+EncodeObjectAPI-8    2.54ms ± 0%    0.51ms ± 0%   -79.85%  (p=0.008 n=5+5)
+DecodeObjectAPI-8    3.57ms ± 0%    0.20ms ± 0%   -94.30%  (p=0.008 n=5+5)
+DecodeSumVec3-8      1.44ms ± 0%    0.16ms ± 0%   -88.86%  (p=0.008 n=5+5)
 
-name               flatbuffers/op   karmem/op   delta
+name               old alloc/op   new alloc/op   delta
 EncodeObjectAPI-8    12.1kB ± 0%     0.0kB       -100.00%  (p=0.008 n=5+5)
-DecodeObjectAPI-8    2.74MB ± 0%    0.03MB ± 0%   -98.83%  (p=0.008 n=5+5)
-DecodeSumVec3-8       0.00B          0.00B           ~     (all equal)    
+DecodeObjectAPI-8    2.87MB ± 0%    0.00MB       -100.00%  (p=0.008 n=5+5)
+DecodeSumVec3-8       0.00B          0.00B           ~     (all equal)
 
-name               flatbuffers/op  karmem/op  delta
+name               old allocs/op  new allocs/op  delta
 EncodeObjectAPI-8     1.00k ± 0%     0.00k       -100.00%  (p=0.008 n=5+5)
-DecodeObjectAPI-8      108k ± 0%        1k ± 0%   -99.07%  (p=0.008 n=5+5)
+DecodeObjectAPI-8      110k ± 0%        0k       -100.00%  (p=0.008 n=5+5)
 DecodeSumVec3-8        0.00           0.00           ~     (all equal)
 ```
 
 **WebAssembly on Wazero (MacOS/ARM64 - M1):**
 
 ```
-name               flatbuffers/op    karmem/op    delta
-EncodeObjectAPI-8    10.1ms ± 0%     2.5ms ± 0%  -75.27%  (p=0.016 n=4+5)
-DecodeObjectAPI-8    31.1ms ± 0%     1.2ms ± 0%  -96.18%  (p=0.008 n=5+5)
-DecodeSumVec3-8      4.44ms ± 0%    0.47ms ± 0%  -89.41%  (p=0.008 n=5+5)
+name               old time/op    new time/op    delta
+EncodeObjectAPI-8    17.2ms ± 0%     4.0ms ± 0%  -76.51%  (p=0.008 n=5+5)
+DecodeObjectAPI-8    50.7ms ± 2%     1.9ms ± 0%  -96.18%  (p=0.008 n=5+5)
+DecodeSumVec3-8      5.74ms ± 0%    0.75ms ± 0%  -86.87%  (p=0.008 n=5+5)
 
-name               flatbuffers/op   karmem/op   delta
-EncodeObjectAPI-8    3.02kB ± 0%    3.02kB ± 0%     ~     (all equal)
-DecodeObjectAPI-8    2.16MB ± 0%    0.01MB ± 0%  -99.45%  (p=0.008 n=5+5)
+name               old alloc/op   new alloc/op   delta
+EncodeObjectAPI-8    3.28kB ± 0%    3.02kB ± 0%   -7.80%  (p=0.008 n=5+5)
+DecodeObjectAPI-8    3.47MB ± 2%    0.02MB ± 0%  -99.56%  (p=0.008 n=5+5)
 DecodeSumVec3-8      1.25kB ± 0%    1.25kB ± 0%     ~     (all equal)
 
-name               flatbuffers/op  karmem/op  delta
+name               old allocs/op  new allocs/op  delta
 EncodeObjectAPI-8      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
-DecodeObjectAPI-8      5.00 ± 0%      5.00 ± 0%     ~     (all equal)
+DecodeObjectAPI-8      5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.008 n=5+5)
 DecodeSumVec3-8        5.00 ± 0%      5.00 ± 0%     ~     (all equal)
 ```
 
@@ -207,7 +207,7 @@ karmem-serialized data.
 
 ```
 name             old time/op    new time/op    delta
-DecodeSumVec3-8    93.7µs ± 0%    98.8µs ± 1%  +5.38%  (p=0.008 n=5+5)
+DecodeSumVec3-8     154µs ± 0%     160µs ± 0%  +4.36%  (p=0.008 n=5+5)
 
 name             old alloc/op   new alloc/op   delta
 DecodeSumVec3-8     0.00B          0.00B         ~     (all equal)
@@ -223,20 +223,20 @@ That is an comparison with all supported languages.
 **WebAssembly on Wazero (MacOS/ARM64 - M1):**
 
 ```
-name \ time/op     result/wasi-go-km.out  result/wasi-as-km.out  result/wasi-zig-km.out  result/wasi-c-km.out  result/wasi-swift-km.out
-DecodeSumVec3-8               470µs ± 0%             932µs ± 0%              231µs ± 0%            230µs ± 0%              97822µs ± 5%
-DecodeObjectAPI-8            1.19ms ± 0%            3.70ms ± 0%             0.62ms ± 0%           0.56ms ± 0%              74.72ms ± 4%
-EncodeObjectAPI-8            2.52ms ± 0%            2.98ms ± 2%             0.71ms ± 0%           0.67ms ± 0%              42.45ms ± 7%
+name \ time/op     result/wasi-go-km.out  result/wasi-as-km.out  result/wasi-zig-km.out  result/wasi-swift-km.out  result/wasi-c-km.out
+DecodeSumVec3-8               754µs ± 0%            1642µs ± 0%              370µs ± 0%               9040µs ± 3%            369µs ± 0%
+DecodeObjectAPI-8            1.94ms ± 0%            6.09ms ± 0%             1.03ms ± 0%              30.77ms ±32%           0.89ms ± 1%
+EncodeObjectAPI-8            4.04ms ± 0%            4.48ms ± 0%             1.15ms ± 0%               8.22ms ± 0%           1.03ms ± 0%
 
-name \ alloc/op    result/wasi-go-km.out  result/wasi-as-km.out  result/wasi-zig-km.out  result/wasi-c-km.out  result/wasi-swift-km.out
-DecodeSumVec3-8              1.25kB ± 0%           12.72kB ± 0%             1.25kB ± 0%           1.25kB ± 0%               2.99kB ± 0%
-DecodeObjectAPI-8            11.9kB ± 1%            74.2kB ± 0%            164.3kB ± 0%            1.2kB ± 0%              291.7kB ± 3%
-EncodeObjectAPI-8            3.02kB ± 0%           38.38kB ± 0%             1.23kB ± 0%           1.23kB ± 0%               2.98kB ± 0%
+name \ alloc/op    result/wasi-go-km.out  result/wasi-as-km.out  result/wasi-zig-km.out  result/wasi-swift-km.out  result/wasi-c-km.out
+DecodeSumVec3-8              1.25kB ± 0%           21.62kB ± 0%             1.25kB ± 0%               1.82kB ± 0%           1.25kB ± 0%
+DecodeObjectAPI-8            15.2kB ± 0%           121.2kB ± 0%            276.1kB ± 1%              108.4kB ± 3%            1.2kB ± 0%
+EncodeObjectAPI-8            3.02kB ± 0%           57.65kB ± 0%             1.23kB ± 0%               1.81kB ± 0%           1.23kB ± 0%
 
-name \ allocs/op   result/wasi-go-km.out  result/wasi-as-km.out  result/wasi-zig-km.out  result/wasi-c-km.out  result/wasi-swift-km.out
-DecodeSumVec3-8                5.00 ± 0%              5.00 ± 0%               5.00 ± 0%             5.00 ± 0%                35.00 ± 0%
-DecodeObjectAPI-8              5.00 ± 0%              4.00 ± 0%               4.00 ± 0%             4.00 ± 0%                35.00 ± 0%
-EncodeObjectAPI-8              4.00 ± 0%              3.00 ± 0%               3.00 ± 0%             3.00 ± 0%                33.00 ± 0%
+name \ allocs/op   result/wasi-go-km.out  result/wasi-as-km.out  result/wasi-zig-km.out  result/wasi-swift-km.out  result/wasi-c-km.out
+DecodeSumVec3-8                5.00 ± 0%              5.00 ± 0%               5.00 ± 0%                32.00 ± 0%             5.00 ± 0%
+DecodeObjectAPI-8              4.00 ± 0%              4.00 ± 0%               4.00 ± 0%                32.00 ± 0%             4.00 ± 0%
+EncodeObjectAPI-8              4.00 ± 0%              3.00 ± 0%               3.00 ± 0%                30.00 ± 0%             3.00 ± 0%
 ```
 
 # Languages
@@ -245,15 +245,15 @@ Currently, we have focus on WebAssembly, and because of that those are the langu
 
 - AssemblyScript
 - Golang/TinyGo
-- ~~Swift/SwiftWasm~~
+- Swift/SwiftWasm
 - Zig
-- C
+- C/Emscripten
 
 ### Features
 
 | Features | Golang | Zig | AssemblyScript | Swift | C |
 |--|-- | -- | --| -- | -- |
-| Performance | Good | Excellent | Good | Horrible | Excellent |
+| Performance | Good | Excellent | Good | Poor | Excellent |
 | Priority | High | High | High | Low | High |
 | **Encoding** | | | | | |
 | Object Encoding | ✔️ |✔️ |✔️ | ✔️ | ✔️|

--- a/benchmark/Package.swift
+++ b/benchmark/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/cmd/karmem/kmgen/swift.go
+++ b/cmd/karmem/kmgen/swift.go
@@ -2,6 +2,7 @@ package kmgen
 
 import (
 	"fmt"
+
 	"karmem.org/cmd/karmem/kmparser"
 )
 
@@ -110,7 +111,7 @@ func (gen *Swift) functions() (f TemplateFunctions) {
 		case kmparser.TypeModelArray, kmparser.TypeModelSlice, kmparser.TypeModelSliceLimited:
 			switch typ.Format {
 			case kmparser.TypeFormatStruct, kmparser.TypeFormatTable:
-				return fmt.Sprintf(`karmem.Slice<%sViewer>`, f.ToPlainType(typ))
+				return fmt.Sprintf(`karmem.SliceStructure<%sViewer>`, f.ToPlainType(typ))
 			default:
 				return fmt.Sprintf(`karmem.Slice<%s>`, p)
 			}

--- a/cmd/karmem/kmgen/swift_template.swifttmpl
+++ b/cmd/karmem/kmgen/swift_template.swifttmpl
@@ -1,5 +1,8 @@
 {{- define "header"}}
 import {{FromTags "import"}}
+
+var _Null : [UInt8] = Array(repeating: 0, count: {{.Size.Largest}})
+var _NullReader = karmem.NewReader(_Null)
 {{- end}}
 {{define "enums"}}
 {{- /*gotype: karmem.org/cmd/karmem/kmparser.File*/ -}}
@@ -64,27 +67,10 @@ public struct {{$root.Data.Name}} {
         {{- end}}
         {{- end }}
         {{- if $field.Data.Type.IsArray }}
-        let __{{$field.Data.Name}}Len = self.{{$field.Data.Name}}.count
-        var __{{$field.Data.Name}}Index = 0
-        while (__{{$field.Data.Name}}Index < __{{$field.Data.Name}}Len) {
-            {{- if not $field.Data.Type.IsNative}}
-                self.{{$field.Data.Name}}[__{{$field.Data.Name}}Index].Reset()
-            {{- else}}
-                self.{{$field.Data.Name}}[__{{$field.Data.Name}}Index] = {{ToDefault $field.Data.Type}}
-            {{- end}}
-            __{{$field.Data.Name}}Index = __{{$field.Data.Name}}Index + 1
-        }
+        self.{{$field.Data.Name}}.removeAll(keepingCapacity: true)
         {{- end }}
         {{- if $field.Data.Type.IsSlice }}
-        {{- if not $field.Data.Type.IsNative}}
-        let __{{$field.Data.Name}}Len = self.{{$field.Data.Name}}.count
-        var __{{$field.Data.Name}}Index = 0
-        while (__{{$field.Data.Name}}Index < __{{$field.Data.Name}}Len) {
-            self.{{$field.Data.Name}}[__{{$field.Data.Name}}Index].Reset()
-            __{{$field.Data.Name}}Index = __{{$field.Data.Name}}Index + 1
-        }
-        {{- end}}
-        self.{{$field.Data.Name}}.removeAll()
+        self.{{$field.Data.Name}}.removeAll(keepingCapacity: true)
         {{- end }}
         {{- end }}
     }
@@ -105,7 +91,7 @@ public struct {{$root.Data.Name}} {
         }
 
         {{- if $root.Data.IsTable }}
-        writer.WriteAt(offset, {{$root.Data.Size.Content}})
+        writer.memory.storeBytes(of: UInt32({{$root.Data.Size.Content}}), toByteOffset: Int(offset), as: UInt32.self)
         {{- end }}
 
         {{- range $field := $root.Data.Fields }}
@@ -131,28 +117,40 @@ public struct {{$root.Data.Name}} {
         if (__{{$field.Data.Name}}Offset == 0) {
             return false
         }
-        writer.WriteAt(offset + {{$field.Data.Offset}}, __{{$field.Data.Name}}Offset)
+        writer.memory.storeBytes(of: UInt32(__{{$field.Data.Name}}Offset), toByteOffset: Int(offset + {{$field.Data.Offset}}), as: UInt32.self)
             {{- if $field.Data.Type.IsSlice }}
-        writer.WriteAt(offset + {{$field.Data.Offset}} + 4, __{{$field.Data.Name}}Size)
-        writer.WriteAt(offset + {{$field.Data.Offset}} + 4 + 4, {{$field.Data.Size.Allocation}})
+        writer.memory.storeBytes(of: UInt32(__{{$field.Data.Name}}Size), toByteOffset: Int(offset + {{$field.Data.Offset}} + 4), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32({{$field.Data.Size.Allocation}}), toByteOffset: Int(offset + {{$field.Data.Offset}} + 4 + 4), as: UInt32.self)
             {{- end}}
         {{- end }}
         {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum }}
         {{- if $field.Data.Type.IsInline}}
         {{- if $field.Data.Type.IsArray}}
-        writer.WriteArrayAt(__{{$field.Data.Name}}Offset, self.{{$field.Data.Name}}, {{$field.Data.Size.Allocation}})
+        var __{{$field.Data.Name}}Index = 0
+        var __{{$field.Data.Name}}CurrentOffset = __{{$field.Data.Name}}Offset
+        while(__{{$field.Data.Name}}Index < self.{{$field.Data.Name}}.count) {
+            writer.memory.storeBytes(of: self.{{$field.Data.Name}}[__{{$field.Data.Name}}Index], toByteOffset: Int(__{{$field.Data.Name}}CurrentOffset), as: {{- if $field.Data.Type.IsString}} UInt8.self {{ else }}{{ToPlainType $field.Data.Type}}.self{{end}})
+            __{{$field.Data.Name}}Index = __{{$field.Data.Name}}Index + 1
+            __{{$field.Data.Name}}CurrentOffset = __{{$field.Data.Name}}CurrentOffset + {{$field.Data.Size.Allocation}}
+        }
         {{- else}}
         {{- if $field.Data.Type.IsEnum}}
-        writer.WriteAt(__{{$field.Data.Name}}Offset, self.{{$field.Data.Name}})
+        writer.memory.storeBytes(of: self.{{$field.Data.Name}}, toByteOffset: Int(__{{$field.Data.Name}}Offset), as: {{- ToPlainType $field.Data.Type}}.self)
         {{- else}}
-        writer.WriteAt(__{{$field.Data.Name}}Offset, self.{{$field.Data.Name}})
+        writer.memory.storeBytes(of: self.{{$field.Data.Name}}, toByteOffset: Int(__{{$field.Data.Name}}Offset), as: {{- ToPlainType $field.Data.Type}}.self)
         {{- end}}
         {{- end}}
         {{- else}}
         {{- if $field.Data.Type.IsSlice}}
-        writer.WriteArrayAt(__{{$field.Data.Name}}Offset, self.{{$field.Data.Name}}, {{$field.Data.Size.Allocation}})
+        var __{{$field.Data.Name}}Index = 0
+        var __{{$field.Data.Name}}CurrentOffset = __{{$field.Data.Name}}Offset
+        while(__{{$field.Data.Name}}Index < self.{{$field.Data.Name}}.count) {
+            writer.memory.storeBytes(of: self.{{$field.Data.Name}}[__{{$field.Data.Name}}Index], toByteOffset: Int(__{{$field.Data.Name}}CurrentOffset), as: {{- if $field.Data.Type.IsString}} UInt8.self {{ else }}{{ToPlainType $field.Data.Type}}.self{{end}})
+            __{{$field.Data.Name}}Index = __{{$field.Data.Name}}Index + 1
+            __{{$field.Data.Name}}CurrentOffset = __{{$field.Data.Name}}CurrentOffset + {{$field.Data.Size.Allocation}}
+        }
         {{- else}}
-        writer.WriteAt(__{{$field.Data.Name}}Offset, self.{{$field.Data.Name}})
+        writer.memory.storeBytes(of: self.{{$field.Data.Name}}, toByteOffset: Int(__{{$field.Data.Name}}Offset), as: {{- ToPlainType $field.Data.Type}}.self)
         {{- end}}
         {{- end}}
         {{- else }}
@@ -201,7 +199,7 @@ public struct {{$root.Data.Name}} {
     {{- if $field.Data.Type.IsSlice}}
     var __{{$field.Data.Name}}Slice = viewer.{{$field.Data.Name}}(reader)
     let __{{$field.Data.Name}}Len = __{{$field.Data.Name}}Slice.count
-    self.{{$field.Data.Name}}.removeAll()
+    self.{{$field.Data.Name}}.removeAll(keepingCapacity: true)
     if (__{{$field.Data.Name}}Len > self.{{$field.Data.Name}}.count) {
         self.{{$field.Data.Name}}.reserveCapacity(__{{$field.Data.Name}}Len)
         var __{{$field.Data.Name}}IndexClear = self.{{$field.Data.Name}}.count
@@ -257,20 +255,20 @@ public func New{{$root.Data.Name}}() -> {{$root.Data.Name}} {
 {{define "struct_builder"}}
 {{- /*gotype: karmem.org/cmd/karmem/kmparser.File*/ -}}
 {{- range $root := .Structs}}
-public struct {{$root.Data.Name}}Viewer {
-    {{- range $key, $padding := $root.Data.Size.TotalGroup }}
-    var _{{$key}}: UInt64 = 0
-    {{- end}}
 
-    public init() {}
+public struct {{$root.Data.Name}}Viewer : karmem.StructureViewer {
+    var _ptr : UnsafeRawPointer
+    public var karmemPointer: UnsafeRawPointer { get { return self._ptr } set(newValue) { self._ptr = newValue } }
+
+    public init(ptr: UnsafeRawPointer) {
+        self._ptr = ptr
+        self.karmemPointer = ptr
+    }
 
     @inline(__always)
     public func SizeOf() -> UInt32 {
         {{- if $root.Data.IsTable}}
-        var size = UInt32(0)
-        return withUnsafePointer(to: self) {
-            return karmem.Load(UnsafeRawPointer($0), 0, &size)
-        }
+        return self.karmemPointer.loadUnaligned(as: UInt32.self)
         {{- else }}
         return {{$root.Data.Size.Total}}
         {{- end }}
@@ -285,11 +283,13 @@ public struct {{$root.Data.Name}}Viewer {
             return {{ToDefault $field.Data.Type}}
             {{- else}}
             {{- if or $field.Data.Type.IsSlice $field.Data.Type.IsArray }}
-            return withUnsafePointer(to: self) {
-                return karmem.NewSlice(UnsafeRawPointer($0), 0, 0, {{- if $field.Data.Type.IsNative}} {{- if $field.Data.Type.IsString}} UInt8(0) {{- else}} {{ToDefault $field.Data.Type}} {{- end}} {{- else}} {{ToPlainType $field.Data.Type}}Viewer() {{- end}})
-            }
+            {{- if $field.Data.Type.IsNative}}
+                return karmem.NewSliceUnaligned(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: {{- if $field.Data.Type.IsString}} UInt8.self {{- else}} {{ToPlainType $field.Data.Type}}.self {{- end}})
+            {{- else }}
+                return karmem.NewSliceStructure(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: {{- ToPlainType $field.Data.Type}}Viewer.self)
+            {{- end }}
             {{- else}}
-            return {{ToPlainTypeView $field.Data.Type}}()
+            return {{ToPlainTypeView $field.Data.Type}}(ptr: _Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }))
             {{- end}}
             {{- end}}
         }
@@ -298,36 +298,27 @@ public struct {{$root.Data.Name}}Viewer {
         {{- if $field.Data.Type.IsInline}}
         {{- if not $field.Data.Type.IsArray}}
         {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum}}
-        var v : {{ ToTypeView $field.Data.Type }} = {{ ToTypeView $field.Data.Type }}({{ToDefault $field.Data.Type}})
-        v = withUnsafePointer(to: self) {
-            return karmem.Load(UnsafeRawPointer($0), {{$field.Data.Offset}}, &v)
-        }
-        return {{- if $field.Data.Type.IsEnum}} {{ToPlainType $field.Data.Type}}(v) {{- else}} v {{- end}}
-        {{- else}}
-        var v : {{ ToTypeView $field.Data.Type }} = {{ ToTypeView $field.Data.Type }}()
-        return withUnsafePointer(to: self) {
-            return karmem.Load(UnsafeRawPointer($0), {{$field.Data.Offset}}, &v)
-        }
-        {{- end}}
-        {{- else}}
-        return withUnsafePointer(to: self) {
-            return karmem.NewSlice(UnsafeRawPointer(UnsafeRawPointer($0) + Int({{$field.Data.Offset}})), {{$field.Data.Type.Length}}, {{$field.Data.Size.Allocation}}, {{- if $field.Data.Type.IsNative}} {{- if $field.Data.Type.IsString}} UInt8(0) {{- else}} {{ToDefault $field.Data.Type}} {{- end}} {{- else}} {{ToPlainType $field.Data.Type}}Viewer() {{- end}})
-        }
-        {{- end}}
-        {{- else}}
-        var offset = UInt32(0)
-        offset = withUnsafePointer(to: self) {
-            return karmem.Load(UnsafeRawPointer($0), {{$field.Data.Offset}}, &offset)
-        }
+        return (self.karmemPointer + {{$field.Data.Offset}}).loadUnaligned(as: {{ ToTypeView $field.Data.Type }}.self)
+        {{- else }}
+        return  {{ ToTypeView $field.Data.Type }}(ptr: self.karmemPointer + {{$field.Data.Offset}})
+        {{- end }}
+        {{- else }}
+        {{- if $field.Data.Type.IsNative}}
+        return karmem.NewSliceUnaligned(UnsafeRawPointer(self.karmemPointer + Int({{$field.Data.Offset}})), {{$field.Data.Type.Length}}, {{$field.Data.Size.Allocation}}, as: {{- if $field.Data.Type.IsString}} UInt8.self {{- else}} {{ToPlainType $field.Data.Type}}.self {{- end}})
+        {{- else }}
+        return karmem.NewSliceStructure(UnsafeRawPointer(self.karmemPointer + Int({{$field.Data.Offset}})), {{$field.Data.Type.Length}}, {{$field.Data.Size.Allocation}}, as: {{- ToPlainType $field.Data.Type}}Viewer.self)
+        {{- end }}
+        {{- end }}
+        {{- else }}
+        let offset = (self.karmemPointer + {{$field.Data.Offset}}).loadUnaligned(as: UInt32.self)
         {{- if $field.Data.Type.IsSlice}}
-        var size = UInt32(0)
-        size = withUnsafePointer(to: self) {
-            return karmem.Load(UnsafeRawPointer($0), {{$field.Data.Offset}} + 4, &size)
-        }
+        let size = (self.karmemPointer + {{$field.Data.Offset}} + 4).loadUnaligned(as: UInt32.self)
         if (!reader.IsValidOffset(offset, size)) {
-            return withUnsafePointer(to: self) {
-               return karmem.NewSlice(UnsafeRawPointer($0), 0, 0, {{- if $field.Data.Type.IsNative}} {{- if $field.Data.Type.IsString}} UInt8(0) {{- else}} {{ToDefault $field.Data.Type}} {{- end}} {{- else}} {{ToPlainType $field.Data.Type}}Viewer() {{- end}})
-            }
+            {{- if $field.Data.Type.IsNative}}
+                return karmem.NewSliceUnaligned(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: {{- if $field.Data.Type.IsString}} UInt8.self {{- else}} {{ToPlainType $field.Data.Type}}.self {{- end}})
+            {{- else }}
+                return karmem.NewSliceStructure(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: {{- ToPlainType $field.Data.Type}}Viewer.self)
+            {{- end }}
         }
 
         var length = size / {{ $field.Data.Size.Allocation }}
@@ -336,7 +327,11 @@ public struct {{$root.Data.Name}}Viewer {
             length = {{$field.Data.Type.Length}}
         }
         {{- end}}
-        return karmem.NewSlice(UnsafeRawPointer(reader.pointer + Int(offset)), length, {{ $field.Data.Size.Allocation }}, {{- if $field.Data.Type.IsNative}} {{- if $field.Data.Type.IsString}} UInt8(0) {{- else}} {{ToDefault $field.Data.Type}} {{- end}} {{- else}} {{ToPlainType $field.Data.Type}}Viewer() {{- end}})
+        {{- if $field.Data.Type.IsNative}}
+        return karmem.NewSliceUnaligned(UnsafeRawPointer(reader.pointer + Int(offset)), length, {{ $field.Data.Size.Allocation }}, as: {{- if $field.Data.Type.IsString}} UInt8.self {{- else}} {{ToPlainType $field.Data.Type}}.self {{- end}})
+        {{- else }}
+        return karmem.NewSliceStructure(UnsafeRawPointer(reader.pointer + Int(offset)), length, {{ $field.Data.Size.Allocation }}, as: {{- ToPlainType $field.Data.Type}}Viewer.self)
+        {{- end }}
         {{- else}}
         return New{{ToPlainType $field.Data.Type}}Viewer(reader, offset)
         {{- end}}
@@ -347,14 +342,13 @@ public struct {{$root.Data.Name}}Viewer {
 
 @inline(__always) public func New{{$root.Data.Name}}Viewer(_ reader: karmem.Reader, _ offset: UInt32) -> {{$root.Data.Name}}Viewer {
     if (!reader.IsValidOffset(offset, {{$root.Data.Size.Minimum}})) {
-        return {{$root.Data.Name}}Viewer()
+        return {{$root.Data.Name}}Viewer(ptr: _Null.withUnsafeBufferPointer({ return UnsafePointer($0.baseAddress!) }))
     }
 
-    var v = {{$root.Data.Name}}Viewer()
-    v = karmem.Load(reader.pointer, Int(offset), &v)
+    let v = {{$root.Data.Name}}Viewer(ptr: UnsafeRawPointer(reader.pointer + Int(offset)))
     {{- if $root.Data.IsTable}}
     if (!reader.IsValidOffset(offset, v.SizeOf())) {
-        return {{$root.Data.Name}}Viewer()
+        return {{$root.Data.Name}}Viewer(ptr: _Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }))
     }
     {{- end}}
     return v

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
That change considerably reduces the dependency on karmem/swift
package, consequently reducing Swift's generics code.

The generated code will use "inline" code. It will also use the
new `loadUnaligned`.
```
name               old time/op    new time/op    delta
DecodeSumVec3-8       112ms ±12%       9ms ± 3%  -91.95%  (p=0.008 n=5+5)
DecodeObjectAPI-8    88.1ms ± 7%    30.8ms ±32%  -65.08%  (p=0.016 n=4+5)
EncodeObjectAPI-8    67.0ms ±56%     8.2ms ± 0%  -87.72%  (p=0.008 n=5+5)

name               old alloc/op   new alloc/op   delta
DecodeSumVec3-8      2.98kB ± 0%    1.82kB ± 0%     ~     (p=0.079 n=4+5)
DecodeObjectAPI-8     359kB ±16%     108kB ± 3%  -69.85%  (p=0.008 n=5+5)
EncodeObjectAPI-8    2.96kB ± 0%    1.81kB ± 0%  -38.92%  (p=0.008 n=5+5)

name               old allocs/op  new allocs/op  delta
DecodeSumVec3-8        33.0 ± 0%      32.0 ± 0%   -3.03%  (p=0.008 n=5+5)
DecodeObjectAPI-8      33.0 ± 0%      32.0 ± 0%   -3.03%  (p=0.008 n=5+5)
EncodeObjectAPI-8      31.0 ± 0%      30.0 ± 0%   -3.23%  (p=0.008 n=5+5)
```

Signed-off-by: Inkeliz <inkeliz@inkeliz.com>