### PR TITLE
kmgen: [c] fix content size

### DIFF
--- a/cmd/karmem/kmgen/c_template.ctmpl
+++ b/cmd/karmem/kmgen/c_template.ctmpl
@@ -237,7 +237,7 @@ typedef struct {
     uint8_t _data[{{$root.Data.Size.Total}}];
 } {{$root.Data.Name}}Viewer;
 
-uint8_t {{$root.Data.Name}}ViewerSize({{$root.Data.Name}}Viewer * x) {
+uint32_t {{$root.Data.Name}}ViewerSize({{$root.Data.Name}}Viewer * x) {
 {{- if $root.Data.IsTable}}
     uint32_t r;
     memcpy(&r, x, 4);


### PR DESCRIPTION
Before that patch the generated code uses uint8_t instead of uint32_t,
which causes issues. That bug was identified when fuzzing and testing
random IDL generators.