### PR TITLE
kmgen,kmparser,benchmark: add packed() document and struct tag

### DIFF
--- a/.builds/fedora.yml
+++ b/.builds/fedora.yml
@@ -94,7 +94,7 @@ tasks:
   - test_swift: |
       cd karmem/benchmark
       ~/swift-wasm-5.7-SNAPSHOT-2022-07-29-a/usr/bin/swift build --triple wasm32-unknown-wasi -v -c release
-      ~/swift-wasm-5.7-SNAPSHOT-2022-07-29-a/usr/bin/swiftc -L ".build/wasm32-unknown-wasi/release" -o "testdata/wasi/swift.wasi" -module-name benchmark -emit-executable @.build/wasm32-unknown-wasi/release/benchmark.product/Objects.LinkFileList -target wasm32-unknown-wasi -sdk ~/swift-wasm-5.7-SNAPSHOT-2022-07-29-a/usr/share/wasi-sysroot -L ~/swift-wasm-5.7-SNAPSHOT-2022-07-29-a/usr/lib -O -Xlinker "--export=_start" -Xlinker "--export=InputMemoryPointer" -Xlinker "--export=OutputMemoryPointer" -Xlinker "--export=KBenchmarkEncodeObjectAPI"  -Xlinker "--export=KBenchmarkDecodeObjectAPI" -Xlinker "--export=KBenchmarkDecodeSumVec3"
+      ~/swift-wasm-5.7-SNAPSHOT-2022-07-29-a/usr/bin/swiftc -L ".build/wasm32-unknown-wasi/release" -o "testdata/wasi/swift.wasi" -module-name benchmark -emit-executable @.build/wasm32-unknown-wasi/release/benchmark.product/Objects.LinkFileList -target wasm32-unknown-wasi -sdk ~/swift-wasm-5.7-SNAPSHOT-2022-07-29-a/usr/share/wasi-sysroot -L ~/swift-wasm-5.7-SNAPSHOT-2022-07-29-a/usr/lib -O -Xlinker "--export=_start" -Xlinker "--export=InputMemoryPointer" -Xlinker "--export=OutputMemoryPointer" -Xlinker "--export=KBenchmarkEncodeObjectAPI" -Xlinker "--export=KBenchmarkDecodeObjectAPI" -Xlinker "--export=KBenchmarkDecodeSumVec3" -Xlinker "--export=KBenchmarkDecodeSumStats" -Xlinker "--export=KBenchmarkDecodeSumUint8" -Xlinker "--export=KNOOP"
       go test -tags wasi,wazero,km,swift -v -bench=. .
   - exit: |
       exit

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ benchmark/zig-cache
 benchmark/zig-out
 benchmark/.builds
 benchmark/testdata/wasi
+benchmark/testdata/bin
 benchmark/result
 swift/Sources

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ That is a small example of how use Karmem.
 ### Schema
 
 ```go
-karmem app @golang.package(`app`);  
+karmem app @packed(true) @golang.package(`app`);  
   
 enum SocialNetwork uint8 { Unknown; Facebook; Instagram; Twitter; TikTok; }  
   
@@ -281,7 +281,7 @@ Karmem uses a custom schema language, which defines structs, enums and types.
 The schema is very simple to understand and define:
 
 ```go
-karmem game @golang.package(`km`) @assemblyscript.import(`../../assemblyscript/karmem`);
+karmem game @packed(true) @golang.package(`km`) @assemblyscript.import(`../../assemblyscript/karmem`);
 
 enum Team uint8 {Humans;Orcs;Zombies;Robots;Aliens;}
 
@@ -314,7 +314,8 @@ struct State table {
 
 ### Header:
 
-Every file must begin with: `karmem {name};`, other optional options can be defined, as shown above.
+Every file must begin with: `karmem {name} [@tag()];`. Other optional tags can be defined, as shown above, it's
+recommended to use the `@packed(true)` option.
 
 ### Types:
 

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -39,12 +39,12 @@ zig: karmem
 	go test -tags wasi,wazero,km,zig -v -bench=. -benchmem -benchtime=5s -count 5 . > result/wasi-zig-km.out
 
 c: karmem
-	emcc c/main.c -o testdata/wasi/c.wasm -s "EXPORTED_FUNCTIONS=_InputMemoryPointer,_OutputMemoryPointer,__start,_KBenchmarkDecodeSumVec3,_KBenchmarkDecodeObjectAPI,_KBenchmarkEncodeObjectAPI, _KBenchmarkDecodeSumVec3" --no-entry -sALLOW_MEMORY_GROWTH -O3 -flto
+	emcc c/main.c -o testdata/wasi/c.wasm --no-entry -sALLOW_MEMORY_GROWTH -O3 -flto
 	go test -tags wasi,wazero,km,c -v -bench=. -benchmem -benchtime=5s -count 5 . > result/wasi-c-km.out
 
 swiftwasm: karmem
 	xcrun --toolchain swiftwasm swift build --triple wasm32-unknown-wasi -v -c release
-	xcrun --toolchain swiftwasm swiftc -L ".build/wasm32-unknown-wasi/release" -o "testdata/wasi/swift.wasi" -module-name benchmark -emit-executable @.build/wasm32-unknown-wasi/release/benchmark.product/Objects.LinkFileList -target wasm32-unknown-wasi -sdk /Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/share/wasi-sysroot -L /Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/lib -O -Xlinker "--export=_start" -Xlinker "--export=InputMemoryPointer" -Xlinker "--export=OutputMemoryPointer" -Xlinker "--export=KBenchmarkEncodeObjectAPI"  -Xlinker "--export=KBenchmarkDecodeObjectAPI" -Xlinker "--export=KBenchmarkDecodeSumVec3"
+	xcrun --toolchain swiftwasm swiftc -L ".build/wasm32-unknown-wasi/release" -o "testdata/wasi/swift.wasi" -module-name benchmark -emit-executable @.build/wasm32-unknown-wasi/release/benchmark.product/Objects.LinkFileList -target wasm32-unknown-wasi -sdk /Library/Developer/Toolchains/swift-wasm-5.7-SNAPSHOT-2022-07-27-a.xctoolchain/usr/share/wasi-sysroot -L /Library/Developer/Toolchains/swift-wasm-5.7-SNAPSHOT-2022-07-27-a.xctoolchain/usr/lib -O -Xlinker "--export=_start" -Xlinker "--export=InputMemoryPointer" -Xlinker "--export=OutputMemoryPointer" -Xlinker "--export=KBenchmarkEncodeObjectAPI"  -Xlinker "--export=KBenchmarkDecodeObjectAPI" -Xlinker "--export=KBenchmarkDecodeSumVec3" -Xlinker "--export=KBenchmarkDecodeSumUint8" -Xlinker "--export=KBenchmarkDecodeSumStats" -Xlinker "--export=KNOOP"
 	go test -tags wasi,wazero,km,swift -v -bench=. -benchmem -benchtime=5s -count 5 . > result/wasi-swift-km.out
 
 odin: karmem
@@ -53,7 +53,7 @@ odin: karmem
 	go test -tags wasi,wazero,odin,km -v -bench=. -benchmem -benchtime=5s -count 5 . > result/wasi-odin-km.out
 
 dotnet: karmem
-	dotnet build -p:IS_WASM=true -p:IS_KARMEM=true -o "testdata/wasi" "dotnet"
+	# dotnet build -p:IS_WASM=true -p:IS_KARMEM=true -o "testdata/wasi" "dotnet"
 	go test -tags wasi,wazero,km,dotnet,nofuzz -v -bench=. -benchmem -benchtime=5s -count 5 -timeout 30m . > result/wasi-dotnet-km.out
 
 	# dotnet build -p:IS_WASM=false -p:IS_KARMEM=true -o "testdata/wasi" "dotnet"

--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -47,6 +47,11 @@ swiftwasm: karmem
 	xcrun --toolchain swiftwasm swiftc -L ".build/wasm32-unknown-wasi/release" -o "testdata/wasi/swift.wasi" -module-name benchmark -emit-executable @.build/wasm32-unknown-wasi/release/benchmark.product/Objects.LinkFileList -target wasm32-unknown-wasi -sdk /Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/share/wasi-sysroot -L /Library/Developer/Toolchains/swift-wasm-5.6.0-RELEASE.xctoolchain/usr/lib -O -Xlinker "--export=_start" -Xlinker "--export=InputMemoryPointer" -Xlinker "--export=OutputMemoryPointer" -Xlinker "--export=KBenchmarkEncodeObjectAPI"  -Xlinker "--export=KBenchmarkDecodeObjectAPI" -Xlinker "--export=KBenchmarkDecodeSumVec3"
 	go test -tags wasi,wazero,km,swift -v -bench=. -benchmem -benchtime=5s -count 5 . > result/wasi-swift-km.out
 
+odin: karmem
+	odin build . -target:wasi_wasm32 -extra-linker-flags:"--lto-O3 --gc-sections"
+	wasm-ld "benchmark.wasm.o" -o "testdata/wasi/odin.wasi" --lto-O3 --gc-sections
+	go test -tags wasi,wazero,odin,km -v -bench=. -benchmem -benchtime=5s -count 5 . > result/wasi-odin-km.out
+
 dotnet: karmem
 	dotnet build -p:IS_WASM=true -p:IS_KARMEM=true -o "testdata/wasi" "dotnet"
 	go test -tags wasi,wazero,km,dotnet,nofuzz -v -bench=. -benchmem -benchtime=5s -count 5 -timeout 30m . > result/wasi-dotnet-km.out
@@ -57,14 +62,9 @@ dotnet: karmem
 	# dotnet build -p:IS_WASM=false -p:IS_FLATBUFFERS=true -p:BYTEBUFFER_NO_BOUNDS_CHECK=true -p:UNSAFE_BYTEBUFFER=true -o "testdata/wasi" "dotnet"
 	# go test -tags tcp,fbs,dotnet -v -bench=. -benchmem -benchtime=5s -count 5 -timeout 30m . > result/tcp-dotnet-fbs.out
 
-odin: karmem
-	odin build . -target:wasi_wasm32 -extra-linker-flags:"--lto-O3 --gc-sections"
-	wasm-ld "benchmark.wasm.o" -o "testdata/wasi/odin.wasi" --lto-O3 --gc-sections
-	go test -tags wasi,wazero,odin,km -v -bench=. -benchmem -benchtime=5s -count 5 . > result/wasi-odin-km.out
-
 results:
 	benchstat result/fbs.out result/km.out
 	benchstat result/wasi-go-fbs.out result/wasi-go-km.out
 	benchstat result/wasi-go-km.out result/wasi-as-km.out result/wasi-zig-km.out result/wasi-swift-km.out result/wasi-c-km.out result/wasi-odin-km.out result/wasi-dotnet-km.out
 
-bench: karmem native tinygo assemblyscript zig c swiftwasm dotnet result
+bench: karmem native tinygo assemblyscript zig c swiftwasm odin dotnet result

--- a/benchmark/c/main.c
+++ b/benchmark/c/main.c
@@ -7,6 +7,7 @@
 uint8_t *InputMemory;
 uint8_t *OutputMemory;
 
+__attribute__((export_name("InputMemoryPointer")))
 uint32_t InputMemoryPointer() {
     if (InputMemory == NULL) {
         return 0xFFFFFFFF;
@@ -14,6 +15,7 @@ uint32_t InputMemoryPointer() {
     return *(uint32_t *) &InputMemory;
 }
 
+__attribute__((export_name("OutputMemoryPointer")))
 uint32_t OutputMemoryPointer() {
     if (OutputMemory == NULL) {
         return 0xFFFFFFFF;
@@ -25,6 +27,7 @@ Monsters _Struct;
 KarmemWriter _Writer;
 KarmemReader _Reader;
 
+__attribute__((export_name("_start")))
 void _start() {
     OutputMemory = (uint8_t *) malloc(8000000);
     InputMemory = (uint8_t *) malloc(8000000);
@@ -33,18 +36,21 @@ void _start() {
     _Reader = KarmemNewReader(InputMemory, 8000000);
 }
 
+__attribute__((export_name("KBenchmarkEncodeObjectAPI")))
 void KBenchmarkEncodeObjectAPI() {
     KarmemWriterReset(&_Writer);
     MonstersWriteAsRoot(&_Struct, &_Writer);
 }
 
+__attribute__((export_name("KBenchmarkDecodeObjectAPI")))
 void KBenchmarkDecodeObjectAPI(uint32_t size) {
     KarmemReaderSetSize(&_Reader, size);
     MonstersReadAsRoot(&_Struct, &_Reader);
 }
 
+__attribute__((export_name("KBenchmarkDecodeSumVec3")))
 float KBenchmarkDecodeSumVec3(uint32_t size) {
-    Vec3 sum = NewVec3();
+    float sum = 0;
 
     KarmemReaderSetSize(&_Reader, size);
 
@@ -63,13 +69,82 @@ float KBenchmarkDecodeSumVec3(uint32_t size) {
             Vec3Viewer * path = MonsterDataViewer_Path(data, &_Reader);
             while (j < jl) {
                 Vec3Viewer * pp = &path[j];
-                sum.X += Vec3Viewer_X(pp);
-                sum.Y += Vec3Viewer_Y(pp);
-                sum.Z += Vec3Viewer_Z(pp);
+                sum += Vec3Viewer_X(pp) + Vec3Viewer_Y(pp) + Vec3Viewer_Z(pp);
                 j++;
             }
         i++;
     }
 
-    return sum.X + sum.Y + sum.Z;
+    return sum;
+}
+
+__attribute__((export_name("KBenchmarkDecodeSumUint8")))
+uint32_t KBenchmarkDecodeSumUint8(uint32_t size) {
+    uint32_t sum = 0;
+
+    KarmemReaderSetSize(&_Reader, size);
+
+    MonstersViewer * monsters = NewMonstersViewer(&_Reader, 0);
+
+    uint32_t il = MonstersViewer_MonstersLength(monsters, &_Reader);
+    uint32_t i = 0;
+
+    MonsterViewer * monsterList = MonstersViewer_Monsters(monsters, &_Reader);
+    while (i < il) {
+            MonsterDataViewer * data = MonsterViewer_Data(&monsterList[i], &_Reader);
+
+            uint32_t jl = MonsterDataViewer_InventoryLength(data, &_Reader);
+            uint32_t j = 0;
+
+            uint8_t * inv = MonsterDataViewer_Inventory(data, &_Reader);
+            while (j < jl) {
+                sum += (uint32_t)(inv[j]);
+                j++;
+            }
+        i++;
+    }
+
+    return sum;
+}
+
+__attribute__((export_name("KBenchmarkDecodeSumStats")))
+uint32_t KBenchmarkDecodeSumStats(uint32_t size) {
+    WeaponData sum = NewWeaponData();
+
+    KarmemReaderSetSize(&_Reader, size);
+
+    MonstersViewer * monsters = NewMonstersViewer(&_Reader, 0);
+
+    uint32_t il = MonstersViewer_MonstersLength(monsters, &_Reader);
+    uint32_t i = 0;
+
+    MonsterViewer * monsterList = MonstersViewer_Monsters(monsters, &_Reader);
+    while (i < il) {
+            MonsterDataViewer * data = MonsterViewer_Data(&monsterList[i], &_Reader);
+
+            uint32_t jl = MonsterDataViewer_WeaponsLength(data);
+            uint32_t j = 0;
+
+            WeaponViewer * weapons = MonsterDataViewer_Weapons(data);
+            while (j < jl) {
+                WeaponDataViewer * d = WeaponViewer_Data(&weapons[j], &_Reader);
+                sum.Ammo += WeaponDataViewer_Ammo(d);
+                sum.Damage += WeaponDataViewer_Damage(d);
+                sum.ClipSize += WeaponDataViewer_ClipSize(d);
+                sum.ReloadTime += WeaponDataViewer_ReloadTime(d);
+                sum.Range += WeaponDataViewer_Range(d);
+                j++;
+            }
+        i++;
+    }
+
+
+    KarmemWriterReset(&_Writer);
+    WeaponDataWriteAsRoot(&sum, &_Writer);
+    return (uint32_t)_Writer.length;
+}
+
+__attribute__((export_name("KNOOP")))
+uint32_t KNOOP() {
+    return 42;
 }

--- a/benchmark/dotnet/Program.c
+++ b/benchmark/dotnet/Program.c
@@ -15,6 +15,26 @@ MonoMethod* _ID_OutputMemoryPointer;
 MonoMethod* _ID_KBenchmarkEncodeObjectAPI;
 MonoMethod* _ID_KBenchmarkDecodeObjectAPI;
 MonoMethod* _ID_KBenchmarkDecodeSumVec3;
+MonoMethod* _ID_KBenchmarkDecodeSumUint8;
+MonoMethod* _ID_KBenchmarkDecodeSumStats;
+MonoMethod* _ID_KNOOP;
+
+void ready_benchmark(MonoObject* cls) {
+    _CLASS_Benchmark = cls;
+
+    _ID_InputMemoryPointer = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "InputMemoryPointer", -1);
+    _ID_OutputMemoryPointer = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "OutputMemoryPointer", -1);
+    _ID_KBenchmarkEncodeObjectAPI = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "KBenchmarkEncodeObjectAPI", -1);
+    _ID_KBenchmarkDecodeObjectAPI = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "KBenchmarkDecodeObjectAPI", -1);
+    _ID_KBenchmarkDecodeSumVec3 = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "KBenchmarkDecodeSumVec3", -1);
+    _ID_KBenchmarkDecodeSumUint8 = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "KBenchmarkDecodeSumUint8", -1);
+    _ID_KBenchmarkDecodeSumStats = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "KBenchmarkDecodeSumStats", -1);
+    _ID_KNOOP = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "KNOOP", -1);
+}
+
+void dotnet_benchmark_init() {
+    mono_add_internal_call ("dotnet.Benchmark::Ready", ready_benchmark);
+}
 
 __attribute__((export_name("InputMemoryPointer")))
 uint32_t InputMemoryPointer() {
@@ -67,17 +87,37 @@ float KBenchmarkDecodeSumVec3(uint32_t size) {
     return *(float*)mono_object_unbox(res);
 }
 
-
-void ready_benchmark(MonoObject* cls) {
-    _CLASS_Benchmark = cls;
-
-    _ID_InputMemoryPointer = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "InputMemoryPointer", -1);
-    _ID_OutputMemoryPointer = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "OutputMemoryPointer", -1);
-    _ID_KBenchmarkEncodeObjectAPI = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "KBenchmarkEncodeObjectAPI", -1);
-    _ID_KBenchmarkDecodeObjectAPI = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "KBenchmarkDecodeObjectAPI", -1);
-    _ID_KBenchmarkDecodeSumVec3 = lookup_dotnet_method("dotnet.dll", "dotnet", "Benchmark", "KBenchmarkDecodeSumVec3", -1);
+__attribute__((export_name("KBenchmarkDecodeSumUint8")))
+uint32_t KBenchmarkDecodeSumUint8(uint32_t size) {
+    void* params[] = { &size };
+    MonoObject* err;
+    MonoObject* res = mono_wasm_invoke_method (_ID_KBenchmarkDecodeSumUint8, _CLASS_Benchmark, params, &err);
+    if (err != NULL)
+    {
+        assert(err);
+    }
+    return *(uint32_t*)mono_object_unbox(res);
 }
 
-void dotnet_benchmark_init() {
-    mono_add_internal_call ("dotnet.Benchmark::Ready", ready_benchmark);
+__attribute__((export_name("KBenchmarkDecodeSumStats")))
+uint32_t KBenchmarkDecodeSumStats(uint32_t size) {
+    void* params[] = { &size };
+    MonoObject* err;
+    MonoObject* res = mono_wasm_invoke_method (_ID_KBenchmarkDecodeSumStats, _CLASS_Benchmark, params, &err);
+    if (err != NULL)
+    {
+        assert(err);
+    }
+    return *(uint32_t*)mono_object_unbox(res);
+}
+
+__attribute__((export_name("KNOOP")))
+uint32_t KNOOP(uint32_t size) {
+    MonoObject* err;
+    MonoObject* res = mono_wasm_invoke_method (_ID_KNOOP, _CLASS_Benchmark, NULL, &err);
+    if (err != NULL)
+    {
+        assert(err);
+    }
+    return *(uint32_t*)mono_object_unbox(res);
 }

--- a/benchmark/km/game_generated.cs
+++ b/benchmark/km/game_generated.cs
@@ -8,7 +8,7 @@ namespace km;
 
 internal static unsafe class _Globals
 {
-    private static long _largest = 152;
+    private static long _largest = 111;
     private static void* _null = null;
     private static Karmem.Reader? _nullReader = null;
 
@@ -82,7 +82,7 @@ public unsafe struct Vec3 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Write(Karmem.Writer writer, uint start) {
         var offset = start;
-        var size = (uint)16;
+        var size = (uint)12;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == uint.MaxValue) {
@@ -140,7 +140,7 @@ public unsafe struct WeaponData {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Write(Karmem.Writer writer, uint start) {
         var offset = start;
-        var size = (uint)16;
+        var size = (uint)12;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == uint.MaxValue) {
@@ -195,14 +195,14 @@ public unsafe struct Weapon {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Write(Karmem.Writer writer, uint start) {
         var offset = start;
-        var size = (uint)8;
+        var size = (uint)4;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == uint.MaxValue) {
                 return false;
             }
         }
-        var __DataSize = (uint)16;
+        var __DataSize = (uint)12;
         var __DataOffset = writer.Alloc(__DataSize);
         if (offset == uint.MaxValue) {
             return false;
@@ -264,48 +264,46 @@ public unsafe struct MonsterData {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Write(Karmem.Writer writer, uint start) {
         var offset = start;
-        var size = (uint)152;
+        var size = (uint)111;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == uint.MaxValue) {
                 return false;
             }
         }
-        writer.WriteAt(offset, (uint)147);
+        writer.WriteAt(offset, (uint)111);
         var __PosOffset = offset+4;
             if (!this._Pos.Write(writer, __PosOffset)) {
                 return false;
             }
-        var __ManaOffset = offset+20;
+        var __ManaOffset = offset+16;
         writer.WriteAt(__ManaOffset, this._Mana);
-        var __HealthOffset = offset+22;
+        var __HealthOffset = offset+18;
         writer.WriteAt(__HealthOffset, this._Health);
         var __NameSize = (uint)(4 * this._Name.Length);
         var __NameOffset = writer.Alloc(__NameSize);
         if (offset == uint.MaxValue) {
             return false;
         }
-        writer.WriteAt(offset+24, (uint)__NameOffset);
-        writer.WriteAt(offset+24 + 4 + 4, (uint)1);
+        writer.WriteAt(offset+20, (uint)__NameOffset);
         var __NameStringSize = writer.WriteAt(__NameOffset, this._Name);
-        writer.WriteAt(offset+24 + 4, (uint)__NameStringSize);
-        var __TeamOffset = offset+36;
+        writer.WriteAt(offset+20 + 4, (uint)__NameStringSize);
+        var __TeamOffset = offset+28;
         writer.WriteAt(__TeamOffset, (long)this._Team);
         var __InventorySize = (uint)(1 * this._Inventory.Count);
         var __InventoryOffset = writer.Alloc(__InventorySize);
         if (offset == uint.MaxValue) {
             return false;
         }
-        writer.WriteAt(offset+37, (uint)__InventoryOffset);
-        writer.WriteAt(offset+37 + 4, (uint)__InventorySize);
-        writer.WriteAt(offset+37 + 4 + 4, (uint)1);
+        writer.WriteAt(offset+29, (uint)__InventoryOffset);
+        writer.WriteAt(offset+29 + 4, (uint)__InventorySize);
         for (var i = 0; i < this._Inventory.Count; i++) {
             writer.WriteAt(__InventoryOffset, this._Inventory[i]);
             __InventoryOffset += 1;
         }
-        var __ColorOffset = offset+49;
+        var __ColorOffset = offset+37;
         writer.WriteAt(__ColorOffset, (long)this._Color);
-        var __HitboxOffset = offset+50;
+        var __HitboxOffset = offset+38;
         for (var i = 0; i < 5; i++) {
             if (i < this._Hitbox.Count) {
                 writer.WriteAt(__HitboxOffset, this._Hitbox[i]);
@@ -319,35 +317,33 @@ public unsafe struct MonsterData {
         if (offset == uint.MaxValue) {
             return false;
         }
-        writer.WriteAt(offset+90, (uint)__StatusOffset);
-        writer.WriteAt(offset+90 + 4, (uint)__StatusSize);
-        writer.WriteAt(offset+90 + 4 + 4, (uint)4);
+        writer.WriteAt(offset+78, (uint)__StatusOffset);
+        writer.WriteAt(offset+78 + 4, (uint)__StatusSize);
         for (var i = 0; i < this._Status.Count; i++) {
             writer.WriteAt(__StatusOffset, this._Status[i]);
             __StatusOffset += 4;
         }
-        var __WeaponsOffset = offset+102;
+        var __WeaponsOffset = offset+86;
             for (var i = 0; i < this._Weapons.Count; i++) {
                 if (!this._Weapons[i].Write(writer, __WeaponsOffset)) {
                     return false;
                 }
-                __WeaponsOffset += 8;
+                __WeaponsOffset += 4;
             }
-        var __PathSize = (uint)(16 * this._Path.Count);
+        var __PathSize = (uint)(12 * this._Path.Count);
         var __PathOffset = writer.Alloc(__PathSize);
         if (offset == uint.MaxValue) {
             return false;
         }
-        writer.WriteAt(offset+134, (uint)__PathOffset);
-        writer.WriteAt(offset+134 + 4, (uint)__PathSize);
-        writer.WriteAt(offset+134 + 4 + 4, (uint)16);
+        writer.WriteAt(offset+102, (uint)__PathOffset);
+        writer.WriteAt(offset+102 + 4, (uint)__PathSize);
             for (var i = 0; i < this._Path.Count; i++) {
                 if (!this._Path[i].Write(writer, __PathOffset)) {
                     return false;
                 }
-                __PathOffset += 16;
+                __PathOffset += 12;
             }
-        var __IsAliveOffset = offset+146;
+        var __IsAliveOffset = offset+110;
         writer.WriteAt(__IsAliveOffset, this._IsAlive);
 
         return true;
@@ -484,14 +480,14 @@ public unsafe struct Monster {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Write(Karmem.Writer writer, uint start) {
         var offset = start;
-        var size = (uint)8;
+        var size = (uint)4;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == uint.MaxValue) {
                 return false;
             }
         }
-        var __DataSize = (uint)152;
+        var __DataSize = (uint)111;
         var __DataOffset = writer.Alloc(__DataSize);
         if (offset == uint.MaxValue) {
             return false;
@@ -542,27 +538,26 @@ public unsafe struct Monsters {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Write(Karmem.Writer writer, uint start) {
         var offset = start;
-        var size = (uint)24;
+        var size = (uint)12;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == uint.MaxValue) {
                 return false;
             }
         }
-        writer.WriteAt(offset, (uint)16);
-        var __MonstersSize = (uint)(8 * this._Monsters.Count);
+        writer.WriteAt(offset, (uint)12);
+        var __MonstersSize = (uint)(4 * this._Monsters.Count);
         var __MonstersOffset = writer.Alloc(__MonstersSize);
         if (offset == uint.MaxValue) {
             return false;
         }
         writer.WriteAt(offset+4, (uint)__MonstersOffset);
         writer.WriteAt(offset+4 + 4, (uint)__MonstersSize);
-        writer.WriteAt(offset+4 + 4 + 4, (uint)8);
             for (var i = 0; i < this._Monsters.Count; i++) {
                 if (!this._Monsters[i].Write(writer, __MonstersOffset)) {
                     return false;
                 }
-                __MonstersOffset += 8;
+                __MonstersOffset += 4;
             }
 
         return true;
@@ -594,14 +589,14 @@ public unsafe struct Monsters {
     }
 }
 
-[StructLayout(LayoutKind.Sequential, Pack=0, Size=16)]
+[StructLayout(LayoutKind.Sequential, Pack=1, Size=12)]
 public unsafe struct Vec3Viewer {
-    private readonly long _0;
-    private readonly long _1;
+    private readonly ulong _0;
+    private readonly uint _1;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref Vec3Viewer NewVec3Viewer(Karmem.Reader reader, uint offset) {
-        if (!reader.IsValidOffset(offset, 16)) {
+        if (!reader.IsValidOffset(offset, 12)) {
             return ref *(Vec3Viewer*)(nuint)_Globals.Null();
         }
         ref Vec3Viewer v = ref *(Vec3Viewer*)(reader.MemoryPointer + offset);
@@ -610,7 +605,7 @@ public unsafe struct Vec3Viewer {
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private uint KarmemSizeOf() {
-        return 16;
+        return 12;
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public float X() {
@@ -626,14 +621,14 @@ public unsafe struct Vec3Viewer {
     }
 }
     
-[StructLayout(LayoutKind.Sequential, Pack=0, Size=16)]
+[StructLayout(LayoutKind.Sequential, Pack=1, Size=12)]
 public unsafe struct WeaponDataViewer {
-    private readonly long _0;
-    private readonly long _1;
+    private readonly ulong _0;
+    private readonly uint _1;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref WeaponDataViewer NewWeaponDataViewer(Karmem.Reader reader, uint offset) {
-        if (!reader.IsValidOffset(offset, 8)) {
+        if (!reader.IsValidOffset(offset, 4)) {
             return ref *(WeaponDataViewer*)(nuint)_Globals.Null();
         }
         ref WeaponDataViewer v = ref *(WeaponDataViewer*)(reader.MemoryPointer + offset);
@@ -663,13 +658,13 @@ public unsafe struct WeaponDataViewer {
     }
 }
     
-[StructLayout(LayoutKind.Sequential, Pack=0, Size=8)]
+[StructLayout(LayoutKind.Sequential, Pack=1, Size=4)]
 public unsafe struct WeaponViewer {
-    private readonly long _0;
+    private readonly uint _0;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref WeaponViewer NewWeaponViewer(Karmem.Reader reader, uint offset) {
-        if (!reader.IsValidOffset(offset, 8)) {
+        if (!reader.IsValidOffset(offset, 4)) {
             return ref *(WeaponViewer*)(nuint)_Globals.Null();
         }
         ref WeaponViewer v = ref *(WeaponViewer*)(reader.MemoryPointer + offset);
@@ -678,7 +673,7 @@ public unsafe struct WeaponViewer {
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private uint KarmemSizeOf() {
-        return 8;
+        return 4;
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref WeaponDataViewer Data(Karmem.Reader reader) {
@@ -687,31 +682,28 @@ public unsafe struct WeaponViewer {
     }
 }
     
-[StructLayout(LayoutKind.Sequential, Pack=0, Size=152)]
+[StructLayout(LayoutKind.Sequential, Pack=1, Size=111)]
 public unsafe struct MonsterDataViewer {
-    private readonly long _0;
-    private readonly long _1;
-    private readonly long _2;
-    private readonly long _3;
-    private readonly long _4;
-    private readonly long _5;
-    private readonly long _6;
-    private readonly long _7;
-    private readonly long _8;
-    private readonly long _9;
-    private readonly long _10;
-    private readonly long _11;
-    private readonly long _12;
-    private readonly long _13;
-    private readonly long _14;
-    private readonly long _15;
-    private readonly long _16;
-    private readonly long _17;
-    private readonly long _18;
+    private readonly ulong _0;
+    private readonly ulong _1;
+    private readonly ulong _2;
+    private readonly ulong _3;
+    private readonly ulong _4;
+    private readonly ulong _5;
+    private readonly ulong _6;
+    private readonly ulong _7;
+    private readonly ulong _8;
+    private readonly ulong _9;
+    private readonly ulong _10;
+    private readonly ulong _11;
+    private readonly ulong _12;
+    private readonly uint _13;
+    private readonly ushort _14;
+    private readonly byte _15;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref MonsterDataViewer NewMonsterDataViewer(Karmem.Reader reader, uint offset) {
-        if (!reader.IsValidOffset(offset, 8)) {
+        if (!reader.IsValidOffset(offset, 4)) {
             return ref *(MonsterDataViewer*)(nuint)_Globals.Null();
         }
         ref MonsterDataViewer v = ref *(MonsterDataViewer*)(reader.MemoryPointer + offset);
@@ -727,32 +719,32 @@ public unsafe struct MonsterDataViewer {
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref Vec3Viewer Pos() {
-        if (4 + 16 > this.KarmemSizeOf()) {
+        if (4 + 12 > this.KarmemSizeOf()) {
             return ref *(Vec3Viewer*)((nuint)_Globals.Null());
         }
         return ref *(Vec3Viewer*)((nuint)Unsafe.AsPointer(ref this) + 4);
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public short Mana() {
-        if (20 + 2 > this.KarmemSizeOf()) {
+        if (16 + 2 > this.KarmemSizeOf()) {
             return 0;
         }
-        return *(short*)((nuint)Unsafe.AsPointer(ref this) + 20);
+        return *(short*)((nuint)Unsafe.AsPointer(ref this) + 16);
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public short Health() {
-        if (22 + 2 > this.KarmemSizeOf()) {
+        if (18 + 2 > this.KarmemSizeOf()) {
             return 0;
         }
-        return *(short*)((nuint)Unsafe.AsPointer(ref this) + 22);
+        return *(short*)((nuint)Unsafe.AsPointer(ref this) + 18);
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public string Name(Karmem.Reader reader) {
-        if (24 + 12 > this.KarmemSizeOf()) {
+        if (20 + 8 > this.KarmemSizeOf()) {
             return "";
         }
-        var offset = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 24);
-        var size = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 24 + 4);
+        var offset = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 20);
+        var size = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 20 + 4);
         if (!reader.IsValidOffset(offset, size)) {
             return "";
         }
@@ -764,18 +756,18 @@ public unsafe struct MonsterDataViewer {
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Team Team() {
-        if (36 + 1 > this.KarmemSizeOf()) {
+        if (28 + 1 > this.KarmemSizeOf()) {
             return 0;
         }
-        return *(Team*)((nuint)Unsafe.AsPointer(ref this) + 36);
+        return *(Team*)((nuint)Unsafe.AsPointer(ref this) + 28);
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<byte> Inventory(Karmem.Reader reader) {
-        if (37 + 12 > this.KarmemSizeOf()) {
+        if (29 + 8 > this.KarmemSizeOf()) {
             return new ReadOnlySpan<byte>();
         }
-        var offset = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 37);
-        var size = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 37 + 4);
+        var offset = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 29);
+        var size = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 29 + 4);
         if (!reader.IsValidOffset(offset, size)) {
             return new ReadOnlySpan<byte>();
         }
@@ -787,25 +779,25 @@ public unsafe struct MonsterDataViewer {
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Color Color() {
-        if (49 + 1 > this.KarmemSizeOf()) {
+        if (37 + 1 > this.KarmemSizeOf()) {
             return 0;
         }
-        return *(Color*)((nuint)Unsafe.AsPointer(ref this) + 49);
+        return *(Color*)((nuint)Unsafe.AsPointer(ref this) + 37);
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<double> Hitbox() {
-        if (50 + 40 > this.KarmemSizeOf()) {
+        if (38 + 40 > this.KarmemSizeOf()) {
             return new ReadOnlySpan<double>();
         }
-        return new ReadOnlySpan<double>((void*)((nuint)Unsafe.AsPointer(ref this) + 50), 5);
+        return new ReadOnlySpan<double>((void*)((nuint)Unsafe.AsPointer(ref this) + 38), 5);
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<int> Status(Karmem.Reader reader) {
-        if (90 + 12 > this.KarmemSizeOf()) {
+        if (78 + 8 > this.KarmemSizeOf()) {
             return new ReadOnlySpan<int>();
         }
-        var offset = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 90);
-        var size = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 90 + 4);
+        var offset = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 78);
+        var size = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 78 + 4);
         if (!reader.IsValidOffset(offset, size)) {
             return new ReadOnlySpan<int>();
         }
@@ -817,22 +809,22 @@ public unsafe struct MonsterDataViewer {
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<WeaponViewer> Weapons() {
-        if (102 + 32 > this.KarmemSizeOf()) {
+        if (86 + 16 > this.KarmemSizeOf()) {
             return new ReadOnlySpan<WeaponViewer>();
         }
-        return new ReadOnlySpan<WeaponViewer>((void*)((nuint)Unsafe.AsPointer(ref this) + 102), 4);
+        return new ReadOnlySpan<WeaponViewer>((void*)((nuint)Unsafe.AsPointer(ref this) + 86), 4);
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<Vec3Viewer> Path(Karmem.Reader reader) {
-        if (134 + 12 > this.KarmemSizeOf()) {
+        if (102 + 8 > this.KarmemSizeOf()) {
             return new ReadOnlySpan<Vec3Viewer>();
         }
-        var offset = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 134);
-        var size = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 134 + 4);
+        var offset = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 102);
+        var size = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 102 + 4);
         if (!reader.IsValidOffset(offset, size)) {
             return new ReadOnlySpan<Vec3Viewer>();
         }
-        var length = size / 16;
+        var length = size / 12;
         if (length > 2000) {
             length = 2000;
         }
@@ -840,20 +832,20 @@ public unsafe struct MonsterDataViewer {
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsAlive() {
-        if (146 + 1 > this.KarmemSizeOf()) {
+        if (110 + 1 > this.KarmemSizeOf()) {
             return false;
         }
-        return *(bool*)((nuint)Unsafe.AsPointer(ref this) + 146);
+        return *(bool*)((nuint)Unsafe.AsPointer(ref this) + 110);
     }
 }
     
-[StructLayout(LayoutKind.Sequential, Pack=0, Size=8)]
+[StructLayout(LayoutKind.Sequential, Pack=1, Size=4)]
 public unsafe struct MonsterViewer {
-    private readonly long _0;
+    private readonly uint _0;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref MonsterViewer NewMonsterViewer(Karmem.Reader reader, uint offset) {
-        if (!reader.IsValidOffset(offset, 8)) {
+        if (!reader.IsValidOffset(offset, 4)) {
             return ref *(MonsterViewer*)(nuint)_Globals.Null();
         }
         ref MonsterViewer v = ref *(MonsterViewer*)(reader.MemoryPointer + offset);
@@ -862,7 +854,7 @@ public unsafe struct MonsterViewer {
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private uint KarmemSizeOf() {
-        return 8;
+        return 4;
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref MonsterDataViewer Data(Karmem.Reader reader) {
@@ -871,15 +863,14 @@ public unsafe struct MonsterViewer {
     }
 }
     
-[StructLayout(LayoutKind.Sequential, Pack=0, Size=24)]
+[StructLayout(LayoutKind.Sequential, Pack=1, Size=12)]
 public unsafe struct MonstersViewer {
-    private readonly long _0;
-    private readonly long _1;
-    private readonly long _2;
+    private readonly ulong _0;
+    private readonly uint _1;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref MonstersViewer NewMonstersViewer(Karmem.Reader reader, uint offset) {
-        if (!reader.IsValidOffset(offset, 8)) {
+        if (!reader.IsValidOffset(offset, 4)) {
             return ref *(MonstersViewer*)(nuint)_Globals.Null();
         }
         ref MonstersViewer v = ref *(MonstersViewer*)(reader.MemoryPointer + offset);
@@ -895,7 +886,7 @@ public unsafe struct MonstersViewer {
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<MonsterViewer> Monsters(Karmem.Reader reader) {
-        if (4 + 12 > this.KarmemSizeOf()) {
+        if (4 + 8 > this.KarmemSizeOf()) {
             return new ReadOnlySpan<MonsterViewer>();
         }
         var offset = *(uint*)((nuint)Unsafe.AsPointer(ref this) + 4);
@@ -903,7 +894,7 @@ public unsafe struct MonstersViewer {
         if (!reader.IsValidOffset(offset, size)) {
             return new ReadOnlySpan<MonsterViewer>();
         }
-        var length = size / 8;
+        var length = size / 4;
         if (length > 2000) {
             length = 2000;
         }

--- a/benchmark/km/game_generated.cs
+++ b/benchmark/km/game_generated.cs
@@ -113,6 +113,9 @@ public unsafe struct Vec3 {
 }
 public unsafe struct WeaponData {
     public int _Damage = 0;
+    public ushort _Ammo = 0;
+    public byte _ClipSize = 0;
+    public float _ReloadTime = 0;
     public int _Range = 0;
 
     public WeaponData() {}
@@ -140,17 +143,23 @@ public unsafe struct WeaponData {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Write(Karmem.Writer writer, uint start) {
         var offset = start;
-        var size = (uint)12;
+        var size = (uint)19;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == uint.MaxValue) {
                 return false;
             }
         }
-        writer.WriteAt(offset, (uint)12);
+        writer.WriteAt(offset, (uint)19);
         var __DamageOffset = offset+4;
         writer.WriteAt(__DamageOffset, this._Damage);
-        var __RangeOffset = offset+8;
+        var __AmmoOffset = offset+8;
+        writer.WriteAt(__AmmoOffset, this._Ammo);
+        var __ClipSizeOffset = offset+10;
+        writer.WriteAt(__ClipSizeOffset, this._ClipSize);
+        var __ReloadTimeOffset = offset+11;
+        writer.WriteAt(__ReloadTimeOffset, this._ReloadTime);
+        var __RangeOffset = offset+15;
         writer.WriteAt(__RangeOffset, this._Range);
 
         return true;
@@ -164,6 +173,9 @@ public unsafe struct WeaponData {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Read(WeaponDataViewer viewer, Karmem.Reader reader) {
         this._Damage = viewer.Damage();
+        this._Ammo = viewer.Ammo();
+        this._ClipSize = viewer.ClipSize();
+        this._ReloadTime = viewer.ReloadTime();
         this._Range = viewer.Range();
     }
 }
@@ -202,7 +214,7 @@ public unsafe struct Weapon {
                 return false;
             }
         }
-        var __DataSize = (uint)12;
+        var __DataSize = (uint)19;
         var __DataOffset = writer.Alloc(__DataSize);
         if (offset == uint.MaxValue) {
             return false;
@@ -621,10 +633,12 @@ public unsafe struct Vec3Viewer {
     }
 }
     
-[StructLayout(LayoutKind.Sequential, Pack=1, Size=12)]
+[StructLayout(LayoutKind.Sequential, Pack=1, Size=19)]
 public unsafe struct WeaponDataViewer {
     private readonly ulong _0;
-    private readonly uint _1;
+    private readonly ulong _1;
+    private readonly ushort _2;
+    private readonly byte _3;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref WeaponDataViewer NewWeaponDataViewer(Karmem.Reader reader, uint offset) {
@@ -650,11 +664,32 @@ public unsafe struct WeaponDataViewer {
         return *(int*)((nuint)Unsafe.AsPointer(ref this) + 4);
     }
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int Range() {
-        if (8 + 4 > this.KarmemSizeOf()) {
+    public ushort Ammo() {
+        if (8 + 2 > this.KarmemSizeOf()) {
             return 0;
         }
-        return *(int*)((nuint)Unsafe.AsPointer(ref this) + 8);
+        return *(ushort*)((nuint)Unsafe.AsPointer(ref this) + 8);
+    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public byte ClipSize() {
+        if (10 + 1 > this.KarmemSizeOf()) {
+            return 0;
+        }
+        return *(byte*)((nuint)Unsafe.AsPointer(ref this) + 10);
+    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float ReloadTime() {
+        if (11 + 4 > this.KarmemSizeOf()) {
+            return 0;
+        }
+        return *(float*)((nuint)Unsafe.AsPointer(ref this) + 11);
+    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Range() {
+        if (15 + 4 > this.KarmemSizeOf()) {
+            return 0;
+        }
+        return *(int*)((nuint)Unsafe.AsPointer(ref this) + 15);
     }
 }
     

--- a/benchmark/km/game_generated.go
+++ b/benchmark/km/game_generated.go
@@ -7,7 +7,7 @@ import (
 
 var _ unsafe.Pointer
 
-var _Null = make([]byte, 152)
+var _Null = make([]byte, 111)
 var _NullReader = karmem.NewReader(_Null)
 
 type (
@@ -69,7 +69,7 @@ func (x *Vec3) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
 
 func (x *Vec3) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(16)
+	size := uint(12)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
@@ -119,7 +119,7 @@ func (x *WeaponData) WriteAsRoot(writer *karmem.Writer) (offset uint, err error)
 
 func (x *WeaponData) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(16)
+	size := uint(12)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
@@ -166,14 +166,14 @@ func (x *Weapon) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
 
 func (x *Weapon) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(8)
+	size := uint(4)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	__DataSize := uint(16)
+	__DataSize := uint(12)
 	__DataOffset, err := writer.Alloc(__DataSize)
 	if err != nil {
 		return 0, err
@@ -227,84 +227,80 @@ func (x *MonsterData) WriteAsRoot(writer *karmem.Writer) (offset uint, err error
 
 func (x *MonsterData) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(152)
+	size := uint(111)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(147))
+	writer.Write4At(offset, uint32(111))
 	__PosOffset := offset + 4
 	if _, err := x.Pos.Write(writer, __PosOffset); err != nil {
 		return offset, err
 	}
-	__ManaOffset := offset + 20
+	__ManaOffset := offset + 16
 	writer.Write2At(__ManaOffset, *(*uint16)(unsafe.Pointer(&x.Mana)))
-	__HealthOffset := offset + 22
+	__HealthOffset := offset + 18
 	writer.Write2At(__HealthOffset, *(*uint16)(unsafe.Pointer(&x.Health)))
 	__NameSize := uint(1 * len(x.Name))
 	__NameOffset, err := writer.Alloc(__NameSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+24, uint32(__NameOffset))
-	writer.Write4At(offset+24+4, uint32(__NameSize))
-	writer.Write4At(offset+24+4+4, 1)
+	writer.Write4At(offset+20, uint32(__NameOffset))
+	writer.Write4At(offset+20+4, uint32(__NameSize))
 	__NameSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Name)), __NameSize, __NameSize}
 	writer.WriteAt(__NameOffset, *(*[]byte)(unsafe.Pointer(&__NameSlice)))
-	__TeamOffset := offset + 36
+	__TeamOffset := offset + 28
 	writer.Write1At(__TeamOffset, *(*uint8)(unsafe.Pointer(&x.Team)))
 	__InventorySize := uint(1 * len(x.Inventory))
 	__InventoryOffset, err := writer.Alloc(__InventorySize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+37, uint32(__InventoryOffset))
-	writer.Write4At(offset+37+4, uint32(__InventorySize))
-	writer.Write4At(offset+37+4+4, 1)
+	writer.Write4At(offset+29, uint32(__InventoryOffset))
+	writer.Write4At(offset+29+4, uint32(__InventorySize))
 	__InventorySlice := *(*[3]uint)(unsafe.Pointer(&x.Inventory))
 	__InventorySlice[1] = __InventorySize
 	__InventorySlice[2] = __InventorySize
 	writer.WriteAt(__InventoryOffset, *(*[]byte)(unsafe.Pointer(&__InventorySlice)))
-	__ColorOffset := offset + 49
+	__ColorOffset := offset + 37
 	writer.Write1At(__ColorOffset, *(*uint8)(unsafe.Pointer(&x.Color)))
-	__HitboxOffset := offset + 50
+	__HitboxOffset := offset + 38
 	writer.WriteAt(__HitboxOffset, (*[40]byte)(unsafe.Pointer(&x.Hitbox))[:])
 	__StatusSize := uint(4 * len(x.Status))
 	__StatusOffset, err := writer.Alloc(__StatusSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+90, uint32(__StatusOffset))
-	writer.Write4At(offset+90+4, uint32(__StatusSize))
-	writer.Write4At(offset+90+4+4, 4)
+	writer.Write4At(offset+78, uint32(__StatusOffset))
+	writer.Write4At(offset+78+4, uint32(__StatusSize))
 	__StatusSlice := *(*[3]uint)(unsafe.Pointer(&x.Status))
 	__StatusSlice[1] = __StatusSize
 	__StatusSlice[2] = __StatusSize
 	writer.WriteAt(__StatusOffset, *(*[]byte)(unsafe.Pointer(&__StatusSlice)))
-	__WeaponsOffset := offset + 102
+	__WeaponsOffset := offset + 86
 	for i := range x.Weapons {
 		if _, err := x.Weapons[i].Write(writer, __WeaponsOffset); err != nil {
 			return offset, err
 		}
-		__WeaponsOffset += 8
+		__WeaponsOffset += 4
 	}
-	__PathSize := uint(16 * len(x.Path))
+	__PathSize := uint(12 * len(x.Path))
 	__PathOffset, err := writer.Alloc(__PathSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+134, uint32(__PathOffset))
-	writer.Write4At(offset+134+4, uint32(__PathSize))
-	writer.Write4At(offset+134+4+4, 16)
+	writer.Write4At(offset+102, uint32(__PathOffset))
+	writer.Write4At(offset+102+4, uint32(__PathSize))
 	for i := range x.Path {
 		if _, err := x.Path[i].Write(writer, __PathOffset); err != nil {
 			return offset, err
 		}
-		__PathOffset += 16
+		__PathOffset += 12
 	}
-	__IsAliveOffset := offset + 146
+	__IsAliveOffset := offset + 110
 	writer.Write1At(__IsAliveOffset, *(*uint8)(unsafe.Pointer(&x.IsAlive)))
 
 	return offset, nil
@@ -403,14 +399,14 @@ func (x *Monster) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
 
 func (x *Monster) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(8)
+	size := uint(4)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	__DataSize := uint(152)
+	__DataSize := uint(111)
 	__DataOffset, err := writer.Alloc(__DataSize)
 	if err != nil {
 		return 0, err
@@ -453,27 +449,26 @@ func (x *Monsters) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
 
 func (x *Monsters) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(24)
+	size := uint(12)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(16))
-	__MonstersSize := uint(8 * len(x.Monsters))
+	writer.Write4At(offset, uint32(12))
+	__MonstersSize := uint(4 * len(x.Monsters))
 	__MonstersOffset, err := writer.Alloc(__MonstersSize)
 	if err != nil {
 		return 0, err
 	}
 	writer.Write4At(offset+4, uint32(__MonstersOffset))
 	writer.Write4At(offset+4+4, uint32(__MonstersSize))
-	writer.Write4At(offset+4+4+4, 8)
 	for i := range x.Monsters {
 		if _, err := x.Monsters[i].Write(writer, __MonstersOffset); err != nil {
 			return offset, err
 		}
-		__MonstersOffset += 8
+		__MonstersOffset += 4
 	}
 
 	return offset, nil
@@ -498,12 +493,10 @@ func (x *Monsters) Read(viewer *MonstersViewer, reader *karmem.Reader) {
 	x.Monsters = x.Monsters[:__MonstersLen]
 }
 
-type Vec3Viewer struct {
-	_data [16]byte
-}
+type Vec3Viewer [12]byte
 
 func NewVec3Viewer(reader *karmem.Reader, offset uint32) (v *Vec3Viewer) {
-	if !reader.IsValidOffset(offset, 16) {
+	if !reader.IsValidOffset(offset, 12) {
 		return (*Vec3Viewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*Vec3Viewer)(unsafe.Add(reader.Pointer, offset))
@@ -511,24 +504,22 @@ func NewVec3Viewer(reader *karmem.Reader, offset uint32) (v *Vec3Viewer) {
 }
 
 func (x *Vec3Viewer) size() uint32 {
-	return 16
+	return 12
 }
 func (x *Vec3Viewer) X() (v float32) {
-	return *(*float32)(unsafe.Add(unsafe.Pointer(&x._data), 0))
+	return *(*float32)(unsafe.Add(unsafe.Pointer(x), 0))
 }
 func (x *Vec3Viewer) Y() (v float32) {
-	return *(*float32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
+	return *(*float32)(unsafe.Add(unsafe.Pointer(x), 4))
 }
 func (x *Vec3Viewer) Z() (v float32) {
-	return *(*float32)(unsafe.Add(unsafe.Pointer(&x._data), 8))
+	return *(*float32)(unsafe.Add(unsafe.Pointer(x), 8))
 }
 
-type WeaponDataViewer struct {
-	_data [16]byte
-}
+type WeaponDataViewer [12]byte
 
 func NewWeaponDataViewer(reader *karmem.Reader, offset uint32) (v *WeaponDataViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*WeaponDataViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*WeaponDataViewer)(unsafe.Add(reader.Pointer, offset))
@@ -539,27 +530,25 @@ func NewWeaponDataViewer(reader *karmem.Reader, offset uint32) (v *WeaponDataVie
 }
 
 func (x *WeaponDataViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *WeaponDataViewer) Damage() (v int32) {
 	if 4+4 > x.size() {
 		return v
 	}
-	return *(*int32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
+	return *(*int32)(unsafe.Add(unsafe.Pointer(x), 4))
 }
 func (x *WeaponDataViewer) Range() (v int32) {
 	if 8+4 > x.size() {
 		return v
 	}
-	return *(*int32)(unsafe.Add(unsafe.Pointer(&x._data), 8))
+	return *(*int32)(unsafe.Add(unsafe.Pointer(x), 8))
 }
 
-type WeaponViewer struct {
-	_data [8]byte
-}
+type WeaponViewer [4]byte
 
 func NewWeaponViewer(reader *karmem.Reader, offset uint32) (v *WeaponViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*WeaponViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*WeaponViewer)(unsafe.Add(reader.Pointer, offset))
@@ -567,19 +556,17 @@ func NewWeaponViewer(reader *karmem.Reader, offset uint32) (v *WeaponViewer) {
 }
 
 func (x *WeaponViewer) size() uint32 {
-	return 8
+	return 4
 }
 func (x *WeaponViewer) Data(reader *karmem.Reader) (v *WeaponDataViewer) {
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 0))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 0))
 	return NewWeaponDataViewer(reader, offset)
 }
 
-type MonsterDataViewer struct {
-	_data [152]byte
-}
+type MonsterDataViewer [111]byte
 
 func NewMonsterDataViewer(reader *karmem.Reader, offset uint32) (v *MonsterDataViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*MonsterDataViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*MonsterDataViewer)(unsafe.Add(reader.Pointer, offset))
@@ -590,32 +577,32 @@ func NewMonsterDataViewer(reader *karmem.Reader, offset uint32) (v *MonsterDataV
 }
 
 func (x *MonsterDataViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *MonsterDataViewer) Pos() (v *Vec3Viewer) {
-	if 4+16 > x.size() {
+	if 4+12 > x.size() {
 		return (*Vec3Viewer)(unsafe.Pointer(&_Null))
 	}
-	return (*Vec3Viewer)(unsafe.Add(unsafe.Pointer(&x._data), 4))
+	return (*Vec3Viewer)(unsafe.Add(unsafe.Pointer(x), 4))
 }
 func (x *MonsterDataViewer) Mana() (v int16) {
-	if 20+2 > x.size() {
+	if 16+2 > x.size() {
 		return v
 	}
-	return *(*int16)(unsafe.Add(unsafe.Pointer(&x._data), 20))
+	return *(*int16)(unsafe.Add(unsafe.Pointer(x), 16))
 }
 func (x *MonsterDataViewer) Health() (v int16) {
-	if 22+2 > x.size() {
+	if 18+2 > x.size() {
 		return v
 	}
-	return *(*int16)(unsafe.Add(unsafe.Pointer(&x._data), 22))
+	return *(*int16)(unsafe.Add(unsafe.Pointer(x), 18))
 }
 func (x *MonsterDataViewer) Name(reader *karmem.Reader) (v string) {
-	if 24+12 > x.size() {
+	if 20+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 24))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 24+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -629,17 +616,17 @@ func (x *MonsterDataViewer) Name(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *MonsterDataViewer) Team() (v Team) {
-	if 36+1 > x.size() {
+	if 28+1 > x.size() {
 		return v
 	}
-	return *(*Team)(unsafe.Add(unsafe.Pointer(&x._data), 36))
+	return *(*Team)(unsafe.Add(unsafe.Pointer(x), 28))
 }
 func (x *MonsterDataViewer) Inventory(reader *karmem.Reader) (v []byte) {
-	if 37+12 > x.size() {
+	if 29+8 > x.size() {
 		return []byte{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 37))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 37+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 29))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 29+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []byte{}
 	}
@@ -653,26 +640,26 @@ func (x *MonsterDataViewer) Inventory(reader *karmem.Reader) (v []byte) {
 	return *(*[]byte)(unsafe.Pointer(&slice))
 }
 func (x *MonsterDataViewer) Color() (v Color) {
-	if 49+1 > x.size() {
+	if 37+1 > x.size() {
 		return v
 	}
-	return *(*Color)(unsafe.Add(unsafe.Pointer(&x._data), 49))
+	return *(*Color)(unsafe.Add(unsafe.Pointer(x), 37))
 }
 func (x *MonsterDataViewer) Hitbox() (v []float64) {
-	if 50+40 > x.size() {
+	if 38+40 > x.size() {
 		return []float64{}
 	}
 	slice := [3]uintptr{
-		uintptr(unsafe.Add(unsafe.Pointer(&x._data), 50)), 5, 5,
+		uintptr(unsafe.Add(unsafe.Pointer(x), 38)), 5, 5,
 	}
 	return *(*[]float64)(unsafe.Pointer(&slice))
 }
 func (x *MonsterDataViewer) Status(reader *karmem.Reader) (v []int32) {
-	if 90+12 > x.size() {
+	if 78+8 > x.size() {
 		return []int32{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 90))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 90+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 78))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 78+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []int32{}
 	}
@@ -686,24 +673,24 @@ func (x *MonsterDataViewer) Status(reader *karmem.Reader) (v []int32) {
 	return *(*[]int32)(unsafe.Pointer(&slice))
 }
 func (x *MonsterDataViewer) Weapons() (v []WeaponViewer) {
-	if 102+32 > x.size() {
+	if 86+16 > x.size() {
 		return []WeaponViewer{}
 	}
 	slice := [3]uintptr{
-		uintptr(unsafe.Add(unsafe.Pointer(&x._data), 102)), 4, 4,
+		uintptr(unsafe.Add(unsafe.Pointer(x), 86)), 4, 4,
 	}
 	return *(*[]WeaponViewer)(unsafe.Pointer(&slice))
 }
 func (x *MonsterDataViewer) Path(reader *karmem.Reader) (v []Vec3Viewer) {
-	if 134+12 > x.size() {
+	if 102+8 > x.size() {
 		return []Vec3Viewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 134))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 134+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 102))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 102+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []Vec3Viewer{}
 	}
-	length := uintptr(size / 16)
+	length := uintptr(size / 12)
 	if length > 2000 {
 		length = 2000
 	}
@@ -713,18 +700,16 @@ func (x *MonsterDataViewer) Path(reader *karmem.Reader) (v []Vec3Viewer) {
 	return *(*[]Vec3Viewer)(unsafe.Pointer(&slice))
 }
 func (x *MonsterDataViewer) IsAlive() (v bool) {
-	if 146+1 > x.size() {
+	if 110+1 > x.size() {
 		return v
 	}
-	return *(*bool)(unsafe.Add(unsafe.Pointer(&x._data), 146))
+	return *(*bool)(unsafe.Add(unsafe.Pointer(x), 110))
 }
 
-type MonsterViewer struct {
-	_data [8]byte
-}
+type MonsterViewer [4]byte
 
 func NewMonsterViewer(reader *karmem.Reader, offset uint32) (v *MonsterViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*MonsterViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*MonsterViewer)(unsafe.Add(reader.Pointer, offset))
@@ -732,19 +717,17 @@ func NewMonsterViewer(reader *karmem.Reader, offset uint32) (v *MonsterViewer) {
 }
 
 func (x *MonsterViewer) size() uint32 {
-	return 8
+	return 4
 }
 func (x *MonsterViewer) Data(reader *karmem.Reader) (v *MonsterDataViewer) {
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 0))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 0))
 	return NewMonsterDataViewer(reader, offset)
 }
 
-type MonstersViewer struct {
-	_data [24]byte
-}
+type MonstersViewer [12]byte
 
 func NewMonstersViewer(reader *karmem.Reader, offset uint32) (v *MonstersViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*MonstersViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*MonstersViewer)(unsafe.Add(reader.Pointer, offset))
@@ -755,18 +738,18 @@ func NewMonstersViewer(reader *karmem.Reader, offset uint32) (v *MonstersViewer)
 }
 
 func (x *MonstersViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *MonstersViewer) Monsters(reader *karmem.Reader) (v []MonsterViewer) {
-	if 4+12 > x.size() {
+	if 4+8 > x.size() {
 		return []MonsterViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []MonsterViewer{}
 	}
-	length := uintptr(size / 8)
+	length := uintptr(size / 4)
 	if length > 2000 {
 		length = 2000
 	}

--- a/benchmark/km/game_generated.go
+++ b/benchmark/km/game_generated.go
@@ -97,8 +97,11 @@ func (x *Vec3) Read(viewer *Vec3Viewer, reader *karmem.Reader) {
 }
 
 type WeaponData struct {
-	Damage int32
-	Range  int32
+	Damage     int32
+	Ammo       uint16
+	ClipSize   uint8
+	ReloadTime float32
+	Range      int32
 }
 
 func NewWeaponData() WeaponData {
@@ -119,17 +122,23 @@ func (x *WeaponData) WriteAsRoot(writer *karmem.Writer) (offset uint, err error)
 
 func (x *WeaponData) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(12)
+	size := uint(19)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(12))
+	writer.Write4At(offset, uint32(19))
 	__DamageOffset := offset + 4
 	writer.Write4At(__DamageOffset, *(*uint32)(unsafe.Pointer(&x.Damage)))
-	__RangeOffset := offset + 8
+	__AmmoOffset := offset + 8
+	writer.Write2At(__AmmoOffset, *(*uint16)(unsafe.Pointer(&x.Ammo)))
+	__ClipSizeOffset := offset + 10
+	writer.Write1At(__ClipSizeOffset, *(*uint8)(unsafe.Pointer(&x.ClipSize)))
+	__ReloadTimeOffset := offset + 11
+	writer.Write4At(__ReloadTimeOffset, *(*uint32)(unsafe.Pointer(&x.ReloadTime)))
+	__RangeOffset := offset + 15
 	writer.Write4At(__RangeOffset, *(*uint32)(unsafe.Pointer(&x.Range)))
 
 	return offset, nil
@@ -141,6 +150,9 @@ func (x *WeaponData) ReadAsRoot(reader *karmem.Reader) {
 
 func (x *WeaponData) Read(viewer *WeaponDataViewer, reader *karmem.Reader) {
 	x.Damage = viewer.Damage()
+	x.Ammo = viewer.Ammo()
+	x.ClipSize = viewer.ClipSize()
+	x.ReloadTime = viewer.ReloadTime()
 	x.Range = viewer.Range()
 }
 
@@ -173,7 +185,7 @@ func (x *Weapon) Write(writer *karmem.Writer, start uint) (offset uint, err erro
 			return 0, err
 		}
 	}
-	__DataSize := uint(12)
+	__DataSize := uint(19)
 	__DataOffset, err := writer.Alloc(__DataSize)
 	if err != nil {
 		return 0, err
@@ -516,7 +528,7 @@ func (x *Vec3Viewer) Z() (v float32) {
 	return *(*float32)(unsafe.Add(unsafe.Pointer(x), 8))
 }
 
-type WeaponDataViewer [12]byte
+type WeaponDataViewer [19]byte
 
 func NewWeaponDataViewer(reader *karmem.Reader, offset uint32) (v *WeaponDataViewer) {
 	if !reader.IsValidOffset(offset, 4) {
@@ -538,11 +550,29 @@ func (x *WeaponDataViewer) Damage() (v int32) {
 	}
 	return *(*int32)(unsafe.Add(unsafe.Pointer(x), 4))
 }
-func (x *WeaponDataViewer) Range() (v int32) {
-	if 8+4 > x.size() {
+func (x *WeaponDataViewer) Ammo() (v uint16) {
+	if 8+2 > x.size() {
 		return v
 	}
-	return *(*int32)(unsafe.Add(unsafe.Pointer(x), 8))
+	return *(*uint16)(unsafe.Add(unsafe.Pointer(x), 8))
+}
+func (x *WeaponDataViewer) ClipSize() (v uint8) {
+	if 10+1 > x.size() {
+		return v
+	}
+	return *(*uint8)(unsafe.Add(unsafe.Pointer(x), 10))
+}
+func (x *WeaponDataViewer) ReloadTime() (v float32) {
+	if 11+4 > x.size() {
+		return v
+	}
+	return *(*float32)(unsafe.Add(unsafe.Pointer(x), 11))
+}
+func (x *WeaponDataViewer) Range() (v int32) {
+	if 15+4 > x.size() {
+		return v
+	}
+	return *(*int32)(unsafe.Add(unsafe.Pointer(x), 15))
 }
 
 type WeaponViewer [4]byte

--- a/benchmark/km/game_generated.h
+++ b/benchmark/km/game_generated.h
@@ -5,7 +5,7 @@
 #include "stdbool.h"
 #include "../../c/karmem.h"
 
-uint8_t _Null[152];
+uint8_t _Null[111];
 
 
 typedef uint8_t EnumColor;
@@ -21,16 +21,18 @@ const EnumTeam EnumTeamRobots = 3UL;
 const EnumTeam EnumTeamAliens = 4UL;
 
 
-typedef struct {
-    uint8_t _data[16];
+#pragma pack(1)
+typedef struct __attribute__((packed)) {
+    uint8_t _data[12];
 } Vec3Viewer;
+#pragma options align=reset
 
 uint32_t Vec3ViewerSize(Vec3Viewer * x) {
-    return 16;
+    return 12;
 }
 
 Vec3Viewer * NewVec3Viewer(KarmemReader * reader, uint32_t offset) {
-    if (KarmemReaderIsValidOffset(reader, offset, 16) == false) {
+    if (KarmemReaderIsValidOffset(reader, offset, 12) == false) {
         return (Vec3Viewer *) &_Null;
     }
     Vec3Viewer * v = (Vec3Viewer *) &reader->pointer[offset];
@@ -55,9 +57,11 @@ float Vec3Viewer_Z(Vec3Viewer * x) {
     return r;
 }
 
-typedef struct {
-    uint8_t _data[16];
+#pragma pack(1)
+typedef struct __attribute__((packed)) {
+    uint8_t _data[12];
 } WeaponDataViewer;
+#pragma options align=reset
 
 uint32_t WeaponDataViewerSize(WeaponDataViewer * x) {
     uint32_t r;
@@ -66,7 +70,7 @@ uint32_t WeaponDataViewerSize(WeaponDataViewer * x) {
 }
 
 WeaponDataViewer * NewWeaponDataViewer(KarmemReader * reader, uint32_t offset) {
-    if (KarmemReaderIsValidOffset(reader, offset, 8) == false) {
+    if (KarmemReaderIsValidOffset(reader, offset, 4) == false) {
         return (WeaponDataViewer *) &_Null;
     }
     WeaponDataViewer * v = (WeaponDataViewer *) &reader->pointer[offset];
@@ -94,16 +98,18 @@ int32_t WeaponDataViewer_Range(WeaponDataViewer * x) {
     return r;
 }
 
-typedef struct {
-    uint8_t _data[8];
+#pragma pack(1)
+typedef struct __attribute__((packed)) {
+    uint8_t _data[4];
 } WeaponViewer;
+#pragma options align=reset
 
 uint32_t WeaponViewerSize(WeaponViewer * x) {
-    return 8;
+    return 4;
 }
 
 WeaponViewer * NewWeaponViewer(KarmemReader * reader, uint32_t offset) {
-    if (KarmemReaderIsValidOffset(reader, offset, 8) == false) {
+    if (KarmemReaderIsValidOffset(reader, offset, 4) == false) {
         return (WeaponViewer *) &_Null;
     }
     WeaponViewer * v = (WeaponViewer *) &reader->pointer[offset];
@@ -116,9 +122,11 @@ WeaponDataViewer * WeaponViewer_Data(WeaponViewer * x, KarmemReader * reader) {
     return NewWeaponDataViewer(reader, offset);
 }
 
-typedef struct {
-    uint8_t _data[152];
+#pragma pack(1)
+typedef struct __attribute__((packed)) {
+    uint8_t _data[111];
 } MonsterDataViewer;
+#pragma options align=reset
 
 uint32_t MonsterDataViewerSize(MonsterDataViewer * x) {
     uint32_t r;
@@ -127,7 +135,7 @@ uint32_t MonsterDataViewerSize(MonsterDataViewer * x) {
 }
 
 MonsterDataViewer * NewMonsterDataViewer(KarmemReader * reader, uint32_t offset) {
-    if (KarmemReaderIsValidOffset(reader, offset, 8) == false) {
+    if (KarmemReaderIsValidOffset(reader, offset, 4) == false) {
         return (MonsterDataViewer *) &_Null;
     }
     MonsterDataViewer * v = (MonsterDataViewer *) &reader->pointer[offset];
@@ -138,37 +146,37 @@ MonsterDataViewer * NewMonsterDataViewer(KarmemReader * reader, uint32_t offset)
 }
 
 Vec3Viewer * MonsterDataViewer_Pos(MonsterDataViewer * x) {
-    if ((4 + 16) > MonsterDataViewerSize(x)) {
+    if ((4 + 12) > MonsterDataViewerSize(x)) {
         return (Vec3Viewer *) &_Null;
     }
         return (Vec3Viewer *) &x->_data[4];
 }
 
 int16_t MonsterDataViewer_Mana(MonsterDataViewer * x) {
-    if ((20 + 2) > MonsterDataViewerSize(x)) {
+    if ((16 + 2) > MonsterDataViewerSize(x)) {
         return 0;
     }
     int16_t r;
-    memcpy(&r, &x->_data[20], 2);
+    memcpy(&r, &x->_data[16], 2);
     return r;
 }
 
 int16_t MonsterDataViewer_Health(MonsterDataViewer * x) {
-    if ((22 + 2) > MonsterDataViewerSize(x)) {
+    if ((18 + 2) > MonsterDataViewerSize(x)) {
         return 0;
     }
     int16_t r;
-    memcpy(&r, &x->_data[22], 2);
+    memcpy(&r, &x->_data[18], 2);
     return r;
 }
 uint32_t MonsterDataViewer_NameLength(MonsterDataViewer * x, KarmemReader * reader) {
-    if ((24 + 12) > MonsterDataViewerSize(x)) {
+    if ((20 + 8) > MonsterDataViewerSize(x)) {
         return 0;
     }
     uint32_t offset;
-    memcpy(&offset, &x->_data[24], 4);
+    memcpy(&offset, &x->_data[20], 4);
     uint32_t size;
-    memcpy(&size, &x->_data[24 + 4], 4);
+    memcpy(&size, &x->_data[20 + 4], 4);
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return 0;
     }
@@ -180,13 +188,13 @@ uint32_t MonsterDataViewer_NameLength(MonsterDataViewer * x, KarmemReader * read
 }
 
 uint8_t * MonsterDataViewer_Name(MonsterDataViewer * x, KarmemReader * reader) {
-    if ((24 + 12) > MonsterDataViewerSize(x)) {
+    if ((20 + 8) > MonsterDataViewerSize(x)) {
         return (uint8_t *) &_Null;
     }
     uint32_t offset;
-    memcpy(&offset, &x->_data[24], 4);
+    memcpy(&offset, &x->_data[20], 4);
     uint32_t size;
-    memcpy(&size, &x->_data[24 + 4], 4);
+    memcpy(&size, &x->_data[20 + 4], 4);
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return (uint8_t *) &_Null;
     }
@@ -195,19 +203,19 @@ uint8_t * MonsterDataViewer_Name(MonsterDataViewer * x, KarmemReader * reader) {
 }
 
 EnumTeam MonsterDataViewer_Team(MonsterDataViewer * x) {
-    if ((36 + 1) > MonsterDataViewerSize(x)) {
+    if ((28 + 1) > MonsterDataViewerSize(x)) {
         return 0;
     }
-        return * (EnumTeam * ) &x->_data[36];
+        return * (EnumTeam * ) &x->_data[28];
 }
 uint32_t MonsterDataViewer_InventoryLength(MonsterDataViewer * x, KarmemReader * reader) {
-    if ((37 + 12) > MonsterDataViewerSize(x)) {
+    if ((29 + 8) > MonsterDataViewerSize(x)) {
         return 0;
     }
     uint32_t offset;
-    memcpy(&offset, &x->_data[37], 4);
+    memcpy(&offset, &x->_data[29], 4);
     uint32_t size;
-    memcpy(&size, &x->_data[37 + 4], 4);
+    memcpy(&size, &x->_data[29 + 4], 4);
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return 0;
     }
@@ -219,13 +227,13 @@ uint32_t MonsterDataViewer_InventoryLength(MonsterDataViewer * x, KarmemReader *
 }
 
 uint8_t * MonsterDataViewer_Inventory(MonsterDataViewer * x, KarmemReader * reader) {
-    if ((37 + 12) > MonsterDataViewerSize(x)) {
+    if ((29 + 8) > MonsterDataViewerSize(x)) {
         return (uint8_t *) &_Null;
     }
     uint32_t offset;
-    memcpy(&offset, &x->_data[37], 4);
+    memcpy(&offset, &x->_data[29], 4);
     uint32_t size;
-    memcpy(&size, &x->_data[37 + 4], 4);
+    memcpy(&size, &x->_data[29 + 4], 4);
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return (uint8_t *) &_Null;
     }
@@ -234,32 +242,32 @@ uint8_t * MonsterDataViewer_Inventory(MonsterDataViewer * x, KarmemReader * read
 }
 
 EnumColor MonsterDataViewer_Color(MonsterDataViewer * x) {
-    if ((49 + 1) > MonsterDataViewerSize(x)) {
+    if ((37 + 1) > MonsterDataViewerSize(x)) {
         return 0;
     }
-        return * (EnumColor * ) &x->_data[49];
+        return * (EnumColor * ) &x->_data[37];
 }
 uint32_t MonsterDataViewer_HitboxLength(MonsterDataViewer * x) {
-    if ((50 + 40) > MonsterDataViewerSize(x)) {
+    if ((38 + 40) > MonsterDataViewerSize(x)) {
         return 0;
     }
     return 5;
 }
 
 double * MonsterDataViewer_Hitbox(MonsterDataViewer * x) {
-    if ((50 + 40) > MonsterDataViewerSize(x)) {
+    if ((38 + 40) > MonsterDataViewerSize(x)) {
         return (double *) &_Null;
     }
-    return (double *) &x->_data[50];
+    return (double *) &x->_data[38];
 }
 uint32_t MonsterDataViewer_StatusLength(MonsterDataViewer * x, KarmemReader * reader) {
-    if ((90 + 12) > MonsterDataViewerSize(x)) {
+    if ((78 + 8) > MonsterDataViewerSize(x)) {
         return 0;
     }
     uint32_t offset;
-    memcpy(&offset, &x->_data[90], 4);
+    memcpy(&offset, &x->_data[78], 4);
     uint32_t size;
-    memcpy(&size, &x->_data[90 + 4], 4);
+    memcpy(&size, &x->_data[78 + 4], 4);
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return 0;
     }
@@ -271,13 +279,13 @@ uint32_t MonsterDataViewer_StatusLength(MonsterDataViewer * x, KarmemReader * re
 }
 
 int32_t * MonsterDataViewer_Status(MonsterDataViewer * x, KarmemReader * reader) {
-    if ((90 + 12) > MonsterDataViewerSize(x)) {
+    if ((78 + 8) > MonsterDataViewerSize(x)) {
         return (int32_t *) &_Null;
     }
     uint32_t offset;
-    memcpy(&offset, &x->_data[90], 4);
+    memcpy(&offset, &x->_data[78], 4);
     uint32_t size;
-    memcpy(&size, &x->_data[90 + 4], 4);
+    memcpy(&size, &x->_data[78 + 4], 4);
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return (int32_t *) &_Null;
     }
@@ -285,30 +293,30 @@ int32_t * MonsterDataViewer_Status(MonsterDataViewer * x, KarmemReader * reader)
     return (int32_t *) &reader->pointer[offset];
 }
 uint32_t MonsterDataViewer_WeaponsLength(MonsterDataViewer * x) {
-    if ((102 + 32) > MonsterDataViewerSize(x)) {
+    if ((86 + 16) > MonsterDataViewerSize(x)) {
         return 0;
     }
     return 4;
 }
 
 WeaponViewer * MonsterDataViewer_Weapons(MonsterDataViewer * x) {
-    if ((102 + 32) > MonsterDataViewerSize(x)) {
+    if ((86 + 16) > MonsterDataViewerSize(x)) {
         return (WeaponViewer *) &_Null;
     }
-    return (WeaponViewer *) &x->_data[102];
+    return (WeaponViewer *) &x->_data[86];
 }
 uint32_t MonsterDataViewer_PathLength(MonsterDataViewer * x, KarmemReader * reader) {
-    if ((134 + 12) > MonsterDataViewerSize(x)) {
+    if ((102 + 8) > MonsterDataViewerSize(x)) {
         return 0;
     }
     uint32_t offset;
-    memcpy(&offset, &x->_data[134], 4);
+    memcpy(&offset, &x->_data[102], 4);
     uint32_t size;
-    memcpy(&size, &x->_data[134 + 4], 4);
+    memcpy(&size, &x->_data[102 + 4], 4);
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return 0;
     }
-    uint32_t length = size / 16;
+    uint32_t length = size / 12;
     if (length > 2000) {
         length = 2000;
     }
@@ -316,39 +324,41 @@ uint32_t MonsterDataViewer_PathLength(MonsterDataViewer * x, KarmemReader * read
 }
 
 Vec3Viewer * MonsterDataViewer_Path(MonsterDataViewer * x, KarmemReader * reader) {
-    if ((134 + 12) > MonsterDataViewerSize(x)) {
+    if ((102 + 8) > MonsterDataViewerSize(x)) {
         return (Vec3Viewer *) &_Null;
     }
     uint32_t offset;
-    memcpy(&offset, &x->_data[134], 4);
+    memcpy(&offset, &x->_data[102], 4);
     uint32_t size;
-    memcpy(&size, &x->_data[134 + 4], 4);
+    memcpy(&size, &x->_data[102 + 4], 4);
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return (Vec3Viewer *) &_Null;
     }
-    uint32_t length = size / 16;
+    uint32_t length = size / 12;
     return (Vec3Viewer *) &reader->pointer[offset];
 }
 
 bool MonsterDataViewer_IsAlive(MonsterDataViewer * x) {
-    if ((146 + 1) > MonsterDataViewerSize(x)) {
+    if ((110 + 1) > MonsterDataViewerSize(x)) {
         return false;
     }
     bool r;
-    memcpy(&r, &x->_data[146], 1);
+    memcpy(&r, &x->_data[110], 1);
     return r;
 }
 
-typedef struct {
-    uint8_t _data[8];
+#pragma pack(1)
+typedef struct __attribute__((packed)) {
+    uint8_t _data[4];
 } MonsterViewer;
+#pragma options align=reset
 
 uint32_t MonsterViewerSize(MonsterViewer * x) {
-    return 8;
+    return 4;
 }
 
 MonsterViewer * NewMonsterViewer(KarmemReader * reader, uint32_t offset) {
-    if (KarmemReaderIsValidOffset(reader, offset, 8) == false) {
+    if (KarmemReaderIsValidOffset(reader, offset, 4) == false) {
         return (MonsterViewer *) &_Null;
     }
     MonsterViewer * v = (MonsterViewer *) &reader->pointer[offset];
@@ -361,9 +371,11 @@ MonsterDataViewer * MonsterViewer_Data(MonsterViewer * x, KarmemReader * reader)
     return NewMonsterDataViewer(reader, offset);
 }
 
-typedef struct {
-    uint8_t _data[24];
+#pragma pack(1)
+typedef struct __attribute__((packed)) {
+    uint8_t _data[12];
 } MonstersViewer;
+#pragma options align=reset
 
 uint32_t MonstersViewerSize(MonstersViewer * x) {
     uint32_t r;
@@ -372,7 +384,7 @@ uint32_t MonstersViewerSize(MonstersViewer * x) {
 }
 
 MonstersViewer * NewMonstersViewer(KarmemReader * reader, uint32_t offset) {
-    if (KarmemReaderIsValidOffset(reader, offset, 8) == false) {
+    if (KarmemReaderIsValidOffset(reader, offset, 4) == false) {
         return (MonstersViewer *) &_Null;
     }
     MonstersViewer * v = (MonstersViewer *) &reader->pointer[offset];
@@ -382,7 +394,7 @@ MonstersViewer * NewMonstersViewer(KarmemReader * reader, uint32_t offset) {
     return v;
 }
 uint32_t MonstersViewer_MonstersLength(MonstersViewer * x, KarmemReader * reader) {
-    if ((4 + 12) > MonstersViewerSize(x)) {
+    if ((4 + 8) > MonstersViewerSize(x)) {
         return 0;
     }
     uint32_t offset;
@@ -392,7 +404,7 @@ uint32_t MonstersViewer_MonstersLength(MonstersViewer * x, KarmemReader * reader
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return 0;
     }
-    uint32_t length = size / 8;
+    uint32_t length = size / 4;
     if (length > 2000) {
         length = 2000;
     }
@@ -400,7 +412,7 @@ uint32_t MonstersViewer_MonstersLength(MonstersViewer * x, KarmemReader * reader
 }
 
 MonsterViewer * MonstersViewer_Monsters(MonstersViewer * x, KarmemReader * reader) {
-    if ((4 + 12) > MonstersViewerSize(x)) {
+    if ((4 + 8) > MonstersViewerSize(x)) {
         return (MonsterViewer *) &_Null;
     }
     uint32_t offset;
@@ -410,7 +422,7 @@ MonsterViewer * MonstersViewer_Monsters(MonstersViewer * x, KarmemReader * reade
     if (KarmemReaderIsValidOffset(reader, offset, size) == false) {
         return (MonsterViewer *) &_Null;
     }
-    uint32_t length = size / 8;
+    uint32_t length = size / 4;
     return (MonsterViewer *) &reader->pointer[offset];
 }
 typedef uint64_t EnumPacketIdentifier;
@@ -435,7 +447,7 @@ EnumPacketIdentifier Vec3PacketIdentifier(Vec3 * x) {
 
 uint32_t Vec3Write(Vec3 * x, KarmemWriter * writer, uint32_t start) {
     uint32_t offset = start;
-    uint32_t size = 16;
+    uint32_t size = 12;
     if (offset == 0) {
         offset = KarmemWriterAlloc(writer, size);
         if (offset == 0xFFFFFFFF) {
@@ -467,7 +479,7 @@ void Vec3ReadAsRoot(Vec3 * x, KarmemReader * reader) {
 }
 
 void Vec3Reset(Vec3 * x) {
-    KarmemReader reader = KarmemNewReader(&_Null[0], 152);
+    KarmemReader reader = KarmemNewReader(&_Null[0], 111);
     Vec3Read(x, (Vec3Viewer *) &_Null, &reader);
 }
 
@@ -487,7 +499,7 @@ EnumPacketIdentifier WeaponDataPacketIdentifier(WeaponData * x) {
 
 uint32_t WeaponDataWrite(WeaponData * x, KarmemWriter * writer, uint32_t start) {
     uint32_t offset = start;
-    uint32_t size = 16;
+    uint32_t size = 12;
     if (offset == 0) {
         offset = KarmemWriterAlloc(writer, size);
         if (offset == 0xFFFFFFFF) {
@@ -518,7 +530,7 @@ void WeaponDataReadAsRoot(WeaponData * x, KarmemReader * reader) {
 }
 
 void WeaponDataReset(WeaponData * x) {
-    KarmemReader reader = KarmemNewReader(&_Null[0], 152);
+    KarmemReader reader = KarmemNewReader(&_Null[0], 111);
     WeaponDataRead(x, (WeaponDataViewer *) &_Null, &reader);
 }
 
@@ -537,14 +549,14 @@ EnumPacketIdentifier WeaponPacketIdentifier(Weapon * x) {
 
 uint32_t WeaponWrite(Weapon * x, KarmemWriter * writer, uint32_t start) {
     uint32_t offset = start;
-    uint32_t size = 8;
+    uint32_t size = 4;
     if (offset == 0) {
         offset = KarmemWriterAlloc(writer, size);
         if (offset == 0xFFFFFFFF) {
             return 0;
         }
     }
-    uint32_t __DataSize = 16;
+    uint32_t __DataSize = 12;
     uint32_t __DataOffset = KarmemWriterAlloc(writer, __DataSize);
 
     KarmemWriterWriteAt(writer, offset+0, (void *) &__DataOffset, 4);
@@ -568,7 +580,7 @@ void WeaponReadAsRoot(Weapon * x, KarmemReader * reader) {
 }
 
 void WeaponReset(Weapon * x) {
-    KarmemReader reader = KarmemNewReader(&_Null[0], 152);
+    KarmemReader reader = KarmemNewReader(&_Null[0], 111);
     WeaponRead(x, (WeaponViewer *) &_Null, &reader);
 }
 
@@ -606,82 +618,74 @@ EnumPacketIdentifier MonsterDataPacketIdentifier(MonsterData * x) {
 
 uint32_t MonsterDataWrite(MonsterData * x, KarmemWriter * writer, uint32_t start) {
     uint32_t offset = start;
-    uint32_t size = 152;
+    uint32_t size = 111;
     if (offset == 0) {
         offset = KarmemWriterAlloc(writer, size);
         if (offset == 0xFFFFFFFF) {
             return 0;
         }
     }
-    uint32_t sizeData = 147;
+    uint32_t sizeData = 111;
     KarmemWriterWriteAt(writer, offset, (void *)&sizeData, 4);
     uint32_t __PosOffset = offset + 4;
     if (Vec3Write(&x->Pos, writer, __PosOffset) == 0) {
         return 0;
     }
-    uint32_t __ManaOffset = offset + 20;
+    uint32_t __ManaOffset = offset + 16;
     KarmemWriterWriteAt(writer, __ManaOffset, (void *) &x->Mana, 2);
-    uint32_t __HealthOffset = offset + 22;
+    uint32_t __HealthOffset = offset + 18;
     KarmemWriterWriteAt(writer, __HealthOffset, (void *) &x->Health, 2);
     uint32_t __NameSize = 1 * x->_Name_len;
     uint32_t __NameOffset = KarmemWriterAlloc(writer, __NameSize);
 
-    KarmemWriterWriteAt(writer, offset+24, (void *) &__NameOffset, 4);
-    KarmemWriterWriteAt(writer, offset+24+4, (void *) &__NameSize, 4);
-    uint32_t __NameSizeEach = 1;
-    KarmemWriterWriteAt(writer, offset+24+4+4, (void *) &__NameSizeEach, 4);
+    KarmemWriterWriteAt(writer, offset+20, (void *) &__NameOffset, 4);
+    KarmemWriterWriteAt(writer, offset+20+4, (void *) &__NameSize, 4);
     KarmemWriterWriteAt(writer, __NameOffset, (void *) x->Name, __NameSize);
-    uint32_t __TeamOffset = offset + 36;
+    uint32_t __TeamOffset = offset + 28;
     KarmemWriterWriteAt(writer, __TeamOffset, (void *) &x->Team, 1);
     uint32_t __InventorySize = 1 * x->_Inventory_len;
     uint32_t __InventoryOffset = KarmemWriterAlloc(writer, __InventorySize);
 
-    KarmemWriterWriteAt(writer, offset+37, (void *) &__InventoryOffset, 4);
-    KarmemWriterWriteAt(writer, offset+37+4, (void *) &__InventorySize, 4);
-    uint32_t __InventorySizeEach = 1;
-    KarmemWriterWriteAt(writer, offset+37+4+4, (void *) &__InventorySizeEach, 4);
+    KarmemWriterWriteAt(writer, offset+29, (void *) &__InventoryOffset, 4);
+    KarmemWriterWriteAt(writer, offset+29+4, (void *) &__InventorySize, 4);
     KarmemWriterWriteAt(writer, __InventoryOffset, (void *) x->Inventory, __InventorySize);
-    uint32_t __ColorOffset = offset + 49;
+    uint32_t __ColorOffset = offset + 37;
     KarmemWriterWriteAt(writer, __ColorOffset, (void *) &x->Color, 1);
     uint32_t __HitboxSize = 40;
-    uint32_t __HitboxOffset = offset + 50;
+    uint32_t __HitboxOffset = offset + 38;
     KarmemWriterWriteAt(writer, __HitboxOffset,(void *) x->Hitbox, __HitboxSize);
     uint32_t __StatusSize = 4 * x->_Status_len;
     uint32_t __StatusOffset = KarmemWriterAlloc(writer, __StatusSize);
 
-    KarmemWriterWriteAt(writer, offset+90, (void *) &__StatusOffset, 4);
-    KarmemWriterWriteAt(writer, offset+90+4, (void *) &__StatusSize, 4);
-    uint32_t __StatusSizeEach = 4;
-    KarmemWriterWriteAt(writer, offset+90+4+4, (void *) &__StatusSizeEach, 4);
+    KarmemWriterWriteAt(writer, offset+78, (void *) &__StatusOffset, 4);
+    KarmemWriterWriteAt(writer, offset+78+4, (void *) &__StatusSize, 4);
     KarmemWriterWriteAt(writer, __StatusOffset, (void *) x->Status, __StatusSize);
-    uint32_t __WeaponsSize = 32;
-    uint32_t __WeaponsOffset = offset + 102;
+    uint32_t __WeaponsSize = 16;
+    uint32_t __WeaponsOffset = offset + 86;
     uint32_t __WeaponsIndex = 0;
     uint32_t __WeaponsEnd = __WeaponsOffset + __WeaponsSize;
     while (__WeaponsOffset < __WeaponsEnd) {
         if (WeaponWrite(&x->Weapons[__WeaponsIndex], writer, __WeaponsOffset) == 0) {
             return 0;
         }
-        __WeaponsOffset = __WeaponsOffset + 8;
+        __WeaponsOffset = __WeaponsOffset + 4;
         __WeaponsIndex = __WeaponsIndex + 1;
     }
-    uint32_t __PathSize = 16 * x->_Path_len;
+    uint32_t __PathSize = 12 * x->_Path_len;
     uint32_t __PathOffset = KarmemWriterAlloc(writer, __PathSize);
 
-    KarmemWriterWriteAt(writer, offset+134, (void *) &__PathOffset, 4);
-    KarmemWriterWriteAt(writer, offset+134+4, (void *) &__PathSize, 4);
-    uint32_t __PathSizeEach = 16;
-    KarmemWriterWriteAt(writer, offset+134+4+4, (void *) &__PathSizeEach, 4);
+    KarmemWriterWriteAt(writer, offset+102, (void *) &__PathOffset, 4);
+    KarmemWriterWriteAt(writer, offset+102+4, (void *) &__PathSize, 4);
     uint32_t __PathIndex = 0;
     uint32_t __PathEnd = __PathOffset + __PathSize;
     while (__PathOffset < __PathEnd) {
         if (Vec3Write(&x->Path[__PathIndex], writer, __PathOffset) == 0) {
             return 0;
         }
-        __PathOffset = __PathOffset + 16;
+        __PathOffset = __PathOffset + 12;
         __PathIndex = __PathIndex + 1;
     }
-    uint32_t __IsAliveOffset = offset + 146;
+    uint32_t __IsAliveOffset = offset + 110;
     KarmemWriterWriteAt(writer, __IsAliveOffset, (void *) &x->IsAlive, 1);
 
     return offset;
@@ -817,7 +821,7 @@ void MonsterDataReadAsRoot(MonsterData * x, KarmemReader * reader) {
 }
 
 void MonsterDataReset(MonsterData * x) {
-    KarmemReader reader = KarmemNewReader(&_Null[0], 152);
+    KarmemReader reader = KarmemNewReader(&_Null[0], 111);
     MonsterDataRead(x, (MonsterDataViewer *) &_Null, &reader);
 }
 
@@ -836,14 +840,14 @@ EnumPacketIdentifier MonsterPacketIdentifier(Monster * x) {
 
 uint32_t MonsterWrite(Monster * x, KarmemWriter * writer, uint32_t start) {
     uint32_t offset = start;
-    uint32_t size = 8;
+    uint32_t size = 4;
     if (offset == 0) {
         offset = KarmemWriterAlloc(writer, size);
         if (offset == 0xFFFFFFFF) {
             return 0;
         }
     }
-    uint32_t __DataSize = 152;
+    uint32_t __DataSize = 111;
     uint32_t __DataOffset = KarmemWriterAlloc(writer, __DataSize);
 
     KarmemWriterWriteAt(writer, offset+0, (void *) &__DataOffset, 4);
@@ -867,7 +871,7 @@ void MonsterReadAsRoot(Monster * x, KarmemReader * reader) {
 }
 
 void MonsterReset(Monster * x) {
-    KarmemReader reader = KarmemNewReader(&_Null[0], 152);
+    KarmemReader reader = KarmemNewReader(&_Null[0], 111);
     MonsterRead(x, (MonsterViewer *) &_Null, &reader);
 }
 
@@ -888,29 +892,27 @@ EnumPacketIdentifier MonstersPacketIdentifier(Monsters * x) {
 
 uint32_t MonstersWrite(Monsters * x, KarmemWriter * writer, uint32_t start) {
     uint32_t offset = start;
-    uint32_t size = 24;
+    uint32_t size = 12;
     if (offset == 0) {
         offset = KarmemWriterAlloc(writer, size);
         if (offset == 0xFFFFFFFF) {
             return 0;
         }
     }
-    uint32_t sizeData = 16;
+    uint32_t sizeData = 12;
     KarmemWriterWriteAt(writer, offset, (void *)&sizeData, 4);
-    uint32_t __MonstersSize = 8 * x->_Monsters_len;
+    uint32_t __MonstersSize = 4 * x->_Monsters_len;
     uint32_t __MonstersOffset = KarmemWriterAlloc(writer, __MonstersSize);
 
     KarmemWriterWriteAt(writer, offset+4, (void *) &__MonstersOffset, 4);
     KarmemWriterWriteAt(writer, offset+4+4, (void *) &__MonstersSize, 4);
-    uint32_t __MonstersSizeEach = 8;
-    KarmemWriterWriteAt(writer, offset+4+4+4, (void *) &__MonstersSizeEach, 4);
     uint32_t __MonstersIndex = 0;
     uint32_t __MonstersEnd = __MonstersOffset + __MonstersSize;
     while (__MonstersOffset < __MonstersEnd) {
         if (MonsterWrite(&x->Monsters[__MonstersIndex], writer, __MonstersOffset) == 0) {
             return 0;
         }
-        __MonstersOffset = __MonstersOffset + 8;
+        __MonstersOffset = __MonstersOffset + 4;
         __MonstersIndex = __MonstersIndex + 1;
     }
 
@@ -950,7 +952,7 @@ void MonstersReadAsRoot(Monsters * x, KarmemReader * reader) {
 }
 
 void MonstersReset(Monsters * x) {
-    KarmemReader reader = KarmemNewReader(&_Null[0], 152);
+    KarmemReader reader = KarmemNewReader(&_Null[0], 111);
     MonstersRead(x, (MonstersViewer *) &_Null, &reader);
 }
 

--- a/benchmark/km/game_generated.h
+++ b/benchmark/km/game_generated.h
@@ -59,7 +59,7 @@ float Vec3Viewer_Z(Vec3Viewer * x) {
 
 #pragma pack(1)
 typedef struct __attribute__((packed)) {
-    uint8_t _data[12];
+    uint8_t _data[19];
 } WeaponDataViewer;
 #pragma options align=reset
 
@@ -89,12 +89,39 @@ int32_t WeaponDataViewer_Damage(WeaponDataViewer * x) {
     return r;
 }
 
+uint16_t WeaponDataViewer_Ammo(WeaponDataViewer * x) {
+    if ((8 + 2) > WeaponDataViewerSize(x)) {
+        return 0;
+    }
+    uint16_t r;
+    memcpy(&r, &x->_data[8], 2);
+    return r;
+}
+
+uint8_t WeaponDataViewer_ClipSize(WeaponDataViewer * x) {
+    if ((10 + 1) > WeaponDataViewerSize(x)) {
+        return 0;
+    }
+    uint8_t r;
+    memcpy(&r, &x->_data[10], 1);
+    return r;
+}
+
+float WeaponDataViewer_ReloadTime(WeaponDataViewer * x) {
+    if ((11 + 4) > WeaponDataViewerSize(x)) {
+        return 0;
+    }
+    float r;
+    memcpy(&r, &x->_data[11], 4);
+    return r;
+}
+
 int32_t WeaponDataViewer_Range(WeaponDataViewer * x) {
-    if ((8 + 4) > WeaponDataViewerSize(x)) {
+    if ((15 + 4) > WeaponDataViewerSize(x)) {
         return 0;
     }
     int32_t r;
-    memcpy(&r, &x->_data[8], 4);
+    memcpy(&r, &x->_data[15], 4);
     return r;
 }
 
@@ -490,6 +517,9 @@ Vec3 NewVec3() {
 }
 typedef struct {
     int32_t Damage;
+    uint16_t Ammo;
+    uint8_t ClipSize;
+    float ReloadTime;
     int32_t Range;
 } WeaponData;
 
@@ -499,18 +529,24 @@ EnumPacketIdentifier WeaponDataPacketIdentifier(WeaponData * x) {
 
 uint32_t WeaponDataWrite(WeaponData * x, KarmemWriter * writer, uint32_t start) {
     uint32_t offset = start;
-    uint32_t size = 12;
+    uint32_t size = 19;
     if (offset == 0) {
         offset = KarmemWriterAlloc(writer, size);
         if (offset == 0xFFFFFFFF) {
             return 0;
         }
     }
-    uint32_t sizeData = 12;
+    uint32_t sizeData = 19;
     KarmemWriterWriteAt(writer, offset, (void *)&sizeData, 4);
     uint32_t __DamageOffset = offset + 4;
     KarmemWriterWriteAt(writer, __DamageOffset, (void *) &x->Damage, 4);
-    uint32_t __RangeOffset = offset + 8;
+    uint32_t __AmmoOffset = offset + 8;
+    KarmemWriterWriteAt(writer, __AmmoOffset, (void *) &x->Ammo, 2);
+    uint32_t __ClipSizeOffset = offset + 10;
+    KarmemWriterWriteAt(writer, __ClipSizeOffset, (void *) &x->ClipSize, 1);
+    uint32_t __ReloadTimeOffset = offset + 11;
+    KarmemWriterWriteAt(writer, __ReloadTimeOffset, (void *) &x->ReloadTime, 4);
+    uint32_t __RangeOffset = offset + 15;
     KarmemWriterWriteAt(writer, __RangeOffset, (void *) &x->Range, 4);
 
     return offset;
@@ -522,6 +558,9 @@ uint32_t WeaponDataWriteAsRoot(WeaponData * x, KarmemWriter * writer) {
 
 void WeaponDataRead(WeaponData * x, WeaponDataViewer * viewer, KarmemReader * reader) {
     x->Damage = WeaponDataViewer_Damage(viewer);
+    x->Ammo = WeaponDataViewer_Ammo(viewer);
+    x->ClipSize = WeaponDataViewer_ClipSize(viewer);
+    x->ReloadTime = WeaponDataViewer_ReloadTime(viewer);
     x->Range = WeaponDataViewer_Range(viewer);
 }
 
@@ -556,7 +595,7 @@ uint32_t WeaponWrite(Weapon * x, KarmemWriter * writer, uint32_t start) {
             return 0;
         }
     }
-    uint32_t __DataSize = 12;
+    uint32_t __DataSize = 19;
     uint32_t __DataOffset = KarmemWriterAlloc(writer, __DataSize);
 
     KarmemWriterWriteAt(writer, offset+0, (void *) &__DataOffset, 4);

--- a/benchmark/km/game_generated.odin
+++ b/benchmark/km/game_generated.odin
@@ -6,7 +6,7 @@ import "core:runtime"
 import "core:mem"
 import "core:reflect"
 
-_Null := [152]byte{}
+_Null := [111]byte{}
 _NullReader := karmem.NewReaderArray(_Null[:])
 
 EnumColor :: enum u8 {
@@ -53,7 +53,7 @@ Vec3WriteAsRoot :: #force_inline proc(x: ^Vec3, writer: ^karmem.Writer) -> (uint
 
 Vec3Write :: proc(x: ^Vec3, writer: ^karmem.Writer, start: uint) -> (uint, karmem.Error) #no_bounds_check {
     offset := start
-    size := u32(16)
+    size := u32(12)
     if offset == 0 {
         off, err := karmem.WriterAlloc(writer, size)
         if err != karmem.Error.ERR_NONE {
@@ -99,7 +99,7 @@ WeaponDataWriteAsRoot :: #force_inline proc(x: ^WeaponData, writer: ^karmem.Writ
 
 WeaponDataWrite :: proc(x: ^WeaponData, writer: ^karmem.Writer, start: uint) -> (uint, karmem.Error) #no_bounds_check {
     offset := start
-    size := u32(16)
+    size := u32(12)
     if offset == 0 {
         off, err := karmem.WriterAlloc(writer, size)
         if err != karmem.Error.ERR_NONE {
@@ -142,7 +142,7 @@ WeaponWriteAsRoot :: #force_inline proc(x: ^Weapon, writer: ^karmem.Writer) -> (
 
 WeaponWrite :: proc(x: ^Weapon, writer: ^karmem.Writer, start: uint) -> (uint, karmem.Error) #no_bounds_check {
     offset := start
-    size := u32(8)
+    size := u32(4)
     if offset == 0 {
         off, err := karmem.WriterAlloc(writer, size)
         if err != karmem.Error.ERR_NONE {
@@ -150,7 +150,7 @@ WeaponWrite :: proc(x: ^Weapon, writer: ^karmem.Writer, start: uint) -> (uint, k
         }
         offset = off
     }
-    __DataSize := u32(16)
+    __DataSize := u32(12)
     __DataOffset, __DataErr := karmem.WriterAlloc(writer, __DataSize)
     if __DataErr != karmem.Error.ERR_NONE {
         return 0, __DataErr
@@ -199,7 +199,7 @@ MonsterDataWriteAsRoot :: #force_inline proc(x: ^MonsterData, writer: ^karmem.Wr
 
 MonsterDataWrite :: proc(x: ^MonsterData, writer: ^karmem.Writer, start: uint) -> (uint, karmem.Error) #no_bounds_check {
     offset := start
-    size := u32(152)
+    size := u32(111)
     if offset == 0 {
         off, err := karmem.WriterAlloc(writer, size)
         if err != karmem.Error.ERR_NONE {
@@ -207,42 +207,40 @@ MonsterDataWrite :: proc(x: ^MonsterData, writer: ^karmem.Writer, start: uint) -
         }
         offset = off
     }
-    karmem.WriterWrite4At(writer, offset, u32(147))
+    karmem.WriterWrite4At(writer, offset, u32(111))
     __PosOffset := offset+4
     if _, err := Vec3Write(&x.Pos, writer, __PosOffset); err != nil {
         return offset, err
     }
-    __ManaOffset := offset+20
+    __ManaOffset := offset+16
     karmem.WriterWrite2At(writer, __ManaOffset, (cast(^u16)&x.Mana)^)
-    __HealthOffset := offset+22
+    __HealthOffset := offset+18
     karmem.WriterWrite2At(writer, __HealthOffset, (cast(^u16)&x.Health)^)
     __NameSize := u32(1 * len(x.Name))
     __NameOffset, __NameErr := karmem.WriterAlloc(writer, __NameSize)
     if __NameErr != karmem.Error.ERR_NONE {
         return 0, __NameErr
     }
-    karmem.WriterWrite4At(writer, offset+24, u32(__NameOffset))
-    karmem.WriterWrite4At(writer, offset+24 + 4, u32(__NameSize))
-    karmem.WriterWrite4At(writer, offset+24 + 4 + 4, 1)
+    karmem.WriterWrite4At(writer, offset+20, u32(__NameOffset))
+    karmem.WriterWrite4At(writer, offset+20 + 4, u32(__NameSize))
     if __NameSize > 0 {
         karmem.WriterWriteAt(writer, __NameOffset, rawptr((cast(^[^]u8)(&x.Name))^), __NameSize)
     }
-    __TeamOffset := offset+36
+    __TeamOffset := offset+28
     karmem.WriterWrite1At(writer, __TeamOffset, (cast(^u8)&x.Team)^)
     __InventorySize := u32(1 * len(x.Inventory))
     __InventoryOffset, __InventoryErr := karmem.WriterAlloc(writer, __InventorySize)
     if __InventoryErr != karmem.Error.ERR_NONE {
         return 0, __InventoryErr
     }
-    karmem.WriterWrite4At(writer, offset+37, u32(__InventoryOffset))
-    karmem.WriterWrite4At(writer, offset+37 + 4, u32(__InventorySize))
-    karmem.WriterWrite4At(writer, offset+37 + 4 + 4, 1)
+    karmem.WriterWrite4At(writer, offset+29, u32(__InventoryOffset))
+    karmem.WriterWrite4At(writer, offset+29 + 4, u32(__InventorySize))
     if __InventorySize > 0 {
         karmem.WriterWriteAt(writer, __InventoryOffset, rawptr(&x.Inventory[0]), __InventorySize)
     }
-    __ColorOffset := offset+49
+    __ColorOffset := offset+37
     karmem.WriterWrite1At(writer, __ColorOffset, (cast(^u8)&x.Color)^)
-    __HitboxOffset := offset+50
+    __HitboxOffset := offset+38
     __HitboxSize := u32(8 * len(x.Hitbox))
     karmem.WriterWriteAt(writer, __HitboxOffset, rawptr(&x.Hitbox), __HitboxSize)
     __StatusSize := u32(4 * len(x.Status))
@@ -250,35 +248,33 @@ MonsterDataWrite :: proc(x: ^MonsterData, writer: ^karmem.Writer, start: uint) -
     if __StatusErr != karmem.Error.ERR_NONE {
         return 0, __StatusErr
     }
-    karmem.WriterWrite4At(writer, offset+90, u32(__StatusOffset))
-    karmem.WriterWrite4At(writer, offset+90 + 4, u32(__StatusSize))
-    karmem.WriterWrite4At(writer, offset+90 + 4 + 4, 4)
+    karmem.WriterWrite4At(writer, offset+78, u32(__StatusOffset))
+    karmem.WriterWrite4At(writer, offset+78 + 4, u32(__StatusSize))
     if __StatusSize > 0 {
         karmem.WriterWriteAt(writer, __StatusOffset, rawptr(&x.Status[0]), __StatusSize)
     }
-    __WeaponsOffset := offset+102
-    __WeaponsSize := u32(8 * len(x.Weapons))
+    __WeaponsOffset := offset+86
+    __WeaponsSize := u32(4 * len(x.Weapons))
     for _, i in x.Weapons {
         if _, err := WeaponWrite(&x.Weapons[i], writer, __WeaponsOffset); err != nil {
             return offset, err
         }
-        __WeaponsOffset += 8
+        __WeaponsOffset += 4
     }
-    __PathSize := u32(16 * len(x.Path))
+    __PathSize := u32(12 * len(x.Path))
     __PathOffset, __PathErr := karmem.WriterAlloc(writer, __PathSize)
     if __PathErr != karmem.Error.ERR_NONE {
         return 0, __PathErr
     }
-    karmem.WriterWrite4At(writer, offset+134, u32(__PathOffset))
-    karmem.WriterWrite4At(writer, offset+134 + 4, u32(__PathSize))
-    karmem.WriterWrite4At(writer, offset+134 + 4 + 4, 16)
+    karmem.WriterWrite4At(writer, offset+102, u32(__PathOffset))
+    karmem.WriterWrite4At(writer, offset+102 + 4, u32(__PathSize))
     for _, i in x.Path {
         if _, err := Vec3Write(&x.Path[i], writer, __PathOffset); err != nil {
             return offset, err
         }
-        __PathOffset += 16
+        __PathOffset += 12
     }
-    __IsAliveOffset := offset+146
+    __IsAliveOffset := offset+110
     karmem.WriterWrite1At(writer, __IsAliveOffset, (cast(^u8)&x.IsAlive)^)
 
     return offset, nil
@@ -369,7 +365,7 @@ MonsterDataRead :: proc(x: ^MonsterData, viewer: ^MonsterDataViewer, reader: ^ka
     }
     __PathSlice := MonsterDataViewerPath(viewer, reader)
     __PathLen := len(__PathSlice)
-    __PathSize := 16 * __PathLen
+    __PathSize := 12 * __PathLen
     if __PathLen > cap(x.Path) {
         __PathRealloc := make([dynamic]Vec3, __PathLen)
         if x.Path != nil {
@@ -406,7 +402,7 @@ MonsterWriteAsRoot :: #force_inline proc(x: ^Monster, writer: ^karmem.Writer) ->
 
 MonsterWrite :: proc(x: ^Monster, writer: ^karmem.Writer, start: uint) -> (uint, karmem.Error) #no_bounds_check {
     offset := start
-    size := u32(8)
+    size := u32(4)
     if offset == 0 {
         off, err := karmem.WriterAlloc(writer, size)
         if err != karmem.Error.ERR_NONE {
@@ -414,7 +410,7 @@ MonsterWrite :: proc(x: ^Monster, writer: ^karmem.Writer, start: uint) -> (uint,
         }
         offset = off
     }
-    __DataSize := u32(152)
+    __DataSize := u32(111)
     __DataOffset, __DataErr := karmem.WriterAlloc(writer, __DataSize)
     if __DataErr != karmem.Error.ERR_NONE {
         return 0, __DataErr
@@ -452,7 +448,7 @@ MonstersWriteAsRoot :: #force_inline proc(x: ^Monsters, writer: ^karmem.Writer) 
 
 MonstersWrite :: proc(x: ^Monsters, writer: ^karmem.Writer, start: uint) -> (uint, karmem.Error) #no_bounds_check {
     offset := start
-    size := u32(24)
+    size := u32(12)
     if offset == 0 {
         off, err := karmem.WriterAlloc(writer, size)
         if err != karmem.Error.ERR_NONE {
@@ -460,20 +456,19 @@ MonstersWrite :: proc(x: ^Monsters, writer: ^karmem.Writer, start: uint) -> (uin
         }
         offset = off
     }
-    karmem.WriterWrite4At(writer, offset, u32(16))
-    __MonstersSize := u32(8 * len(x.Monsters))
+    karmem.WriterWrite4At(writer, offset, u32(12))
+    __MonstersSize := u32(4 * len(x.Monsters))
     __MonstersOffset, __MonstersErr := karmem.WriterAlloc(writer, __MonstersSize)
     if __MonstersErr != karmem.Error.ERR_NONE {
         return 0, __MonstersErr
     }
     karmem.WriterWrite4At(writer, offset+4, u32(__MonstersOffset))
     karmem.WriterWrite4At(writer, offset+4 + 4, u32(__MonstersSize))
-    karmem.WriterWrite4At(writer, offset+4 + 4 + 4, 8)
     for _, i in x.Monsters {
         if _, err := MonsterWrite(&x.Monsters[i], writer, __MonstersOffset); err != nil {
             return offset, err
         }
-        __MonstersOffset += 8
+        __MonstersOffset += 4
     }
 
     return offset, nil
@@ -486,7 +481,7 @@ MonstersReadAsRoot :: #force_inline proc(x: ^Monsters, reader: ^karmem.Reader) #
 MonstersRead :: proc(x: ^Monsters, viewer: ^MonstersViewer, reader: ^karmem.Reader) #no_bounds_check {
     __MonstersSlice := MonstersViewerMonsters(viewer, reader)
     __MonstersLen := len(__MonstersSlice)
-    __MonstersSize := 8 * __MonstersLen
+    __MonstersSize := 4 * __MonstersLen
     if __MonstersLen > cap(x.Monsters) {
         __MonstersRealloc := make([dynamic]Monster, __MonstersLen)
         if x.Monsters != nil {
@@ -506,11 +501,11 @@ MonstersRead :: proc(x: ^Monsters, viewer: ^MonstersViewer, reader: ^karmem.Read
 }
 
 Vec3Viewer :: struct #packed {
-    _data: [16]byte
+    _data: [12]byte
 }
 
 NewVec3Viewer :: #force_inline proc(reader: ^karmem.Reader, offset: u32) -> ^Vec3Viewer  #no_bounds_check {
-    if karmem.ReaderIsValidOffset(reader, offset, 16) == false {
+    if karmem.ReaderIsValidOffset(reader, offset, 12) == false {
         return (^Vec3Viewer)(&_Null)
     }
     v := cast(^Vec3Viewer)(mem.ptr_offset(cast([^]u8)(reader.pointer), offset))
@@ -518,7 +513,7 @@ NewVec3Viewer :: #force_inline proc(reader: ^karmem.Reader, offset: u32) -> ^Vec
 }
 
 Vec3ViewerSize :: #force_inline proc(x: ^Vec3Viewer) -> u32 #no_bounds_check {
-    return 16
+    return 12
 }
 Vec3ViewerX :: #force_inline proc(x: ^Vec3Viewer,) -> f32 #no_bounds_check {
     return ((^f32)(mem.ptr_offset(cast([^]u8)(x), 0)))^
@@ -530,11 +525,11 @@ Vec3ViewerZ :: #force_inline proc(x: ^Vec3Viewer,) -> f32 #no_bounds_check {
     return ((^f32)(mem.ptr_offset(cast([^]u8)(x), 8)))^
 }
 WeaponDataViewer :: struct #packed {
-    _data: [16]byte
+    _data: [12]byte
 }
 
 NewWeaponDataViewer :: #force_inline proc(reader: ^karmem.Reader, offset: u32) -> ^WeaponDataViewer  #no_bounds_check {
-    if karmem.ReaderIsValidOffset(reader, offset, 8) == false {
+    if karmem.ReaderIsValidOffset(reader, offset, 4) == false {
         return (^WeaponDataViewer)(&_Null)
     }
     v := cast(^WeaponDataViewer)(mem.ptr_offset(cast([^]u8)(reader.pointer), offset))
@@ -560,11 +555,11 @@ WeaponDataViewerRange :: #force_inline proc(x: ^WeaponDataViewer,) -> i32 #no_bo
     return ((^i32)(mem.ptr_offset(cast([^]u8)(x), 8)))^
 }
 WeaponViewer :: struct #packed {
-    _data: [8]byte
+    _data: [4]byte
 }
 
 NewWeaponViewer :: #force_inline proc(reader: ^karmem.Reader, offset: u32) -> ^WeaponViewer  #no_bounds_check {
-    if karmem.ReaderIsValidOffset(reader, offset, 8) == false {
+    if karmem.ReaderIsValidOffset(reader, offset, 4) == false {
         return (^WeaponViewer)(&_Null)
     }
     v := cast(^WeaponViewer)(mem.ptr_offset(cast([^]u8)(reader.pointer), offset))
@@ -572,18 +567,18 @@ NewWeaponViewer :: #force_inline proc(reader: ^karmem.Reader, offset: u32) -> ^W
 }
 
 WeaponViewerSize :: #force_inline proc(x: ^WeaponViewer) -> u32 #no_bounds_check {
-    return 8
+    return 4
 }
 WeaponViewerData :: #force_inline proc(x: ^WeaponViewer,reader: ^karmem.Reader) -> ^WeaponDataViewer #no_bounds_check {
     offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 0)))^
     return NewWeaponDataViewer(reader, offset)
 }
 MonsterDataViewer :: struct #packed {
-    _data: [152]byte
+    _data: [111]byte
 }
 
 NewMonsterDataViewer :: #force_inline proc(reader: ^karmem.Reader, offset: u32) -> ^MonsterDataViewer  #no_bounds_check {
-    if karmem.ReaderIsValidOffset(reader, offset, 8) == false {
+    if karmem.ReaderIsValidOffset(reader, offset, 4) == false {
         return (^MonsterDataViewer)(&_Null)
     }
     v := cast(^MonsterDataViewer)(mem.ptr_offset(cast([^]u8)(reader.pointer), offset))
@@ -597,29 +592,29 @@ MonsterDataViewerSize :: #force_inline proc(x: ^MonsterDataViewer) -> u32 #no_bo
     return ((^u32)(x))^
 }
 MonsterDataViewerPos :: #force_inline proc(x: ^MonsterDataViewer,) -> ^Vec3Viewer #no_bounds_check {
-    if 4 + 16 > MonsterDataViewerSize(x) {
+    if 4 + 12 > MonsterDataViewerSize(x) {
         return (^Vec3Viewer)(&_Null)
     }
     return ((^Vec3Viewer)(mem.ptr_offset(cast([^]u8)(x), 4)))
 }
 MonsterDataViewerMana :: #force_inline proc(x: ^MonsterDataViewer,) -> i16 #no_bounds_check {
-    if 20 + 2 > MonsterDataViewerSize(x) {
+    if 16 + 2 > MonsterDataViewerSize(x) {
         return 0
     }
-    return ((^i16)(mem.ptr_offset(cast([^]u8)(x), 20)))^
+    return ((^i16)(mem.ptr_offset(cast([^]u8)(x), 16)))^
 }
 MonsterDataViewerHealth :: #force_inline proc(x: ^MonsterDataViewer,) -> i16 #no_bounds_check {
-    if 22 + 2 > MonsterDataViewerSize(x) {
+    if 18 + 2 > MonsterDataViewerSize(x) {
         return 0
     }
-    return ((^i16)(mem.ptr_offset(cast([^]u8)(x), 22)))^
+    return ((^i16)(mem.ptr_offset(cast([^]u8)(x), 18)))^
 }
 MonsterDataViewerName :: #force_inline proc(x: ^MonsterDataViewer,reader: ^karmem.Reader) -> string #no_bounds_check {
-    if 24 + 12 > MonsterDataViewerSize(x) {
+    if 20 + 8 > MonsterDataViewerSize(x) {
         return ""
     }
-    offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 24)))^
-    size := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 24 + 4)))^
+    offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 20)))^
+    size := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 20 + 4)))^
     if karmem.ReaderIsValidOffset(reader, offset, size) == false {
         return ""
     }
@@ -635,17 +630,17 @@ MonsterDataViewerName :: #force_inline proc(x: ^MonsterDataViewer,reader: ^karme
     return (cast(^string)(&slice))^
 }
 MonsterDataViewerTeam :: #force_inline proc(x: ^MonsterDataViewer,) -> EnumTeam #no_bounds_check {
-    if 36 + 1 > MonsterDataViewerSize(x) {
+    if 28 + 1 > MonsterDataViewerSize(x) {
         return EnumTeam(0)
     }
-    return ((^EnumTeam)(mem.ptr_offset(cast([^]u8)(x), 36)))^
+    return ((^EnumTeam)(mem.ptr_offset(cast([^]u8)(x), 28)))^
 }
 MonsterDataViewerInventory :: #force_inline proc(x: ^MonsterDataViewer,reader: ^karmem.Reader) -> []u8 #no_bounds_check {
-    if 37 + 12 > MonsterDataViewerSize(x) {
+    if 29 + 8 > MonsterDataViewerSize(x) {
         return []u8{}
     }
-    offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 37)))^
-    size := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 37 + 4)))^
+    offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 29)))^
+    size := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 29 + 4)))^
     if karmem.ReaderIsValidOffset(reader, offset, size) == false {
         return []u8{}
     }
@@ -661,26 +656,26 @@ MonsterDataViewerInventory :: #force_inline proc(x: ^MonsterDataViewer,reader: ^
     return (cast(^[]u8)(&slice))^
 }
 MonsterDataViewerColor :: #force_inline proc(x: ^MonsterDataViewer,) -> EnumColor #no_bounds_check {
-    if 49 + 1 > MonsterDataViewerSize(x) {
+    if 37 + 1 > MonsterDataViewerSize(x) {
         return EnumColor(0)
     }
-    return ((^EnumColor)(mem.ptr_offset(cast([^]u8)(x), 49)))^
+    return ((^EnumColor)(mem.ptr_offset(cast([^]u8)(x), 37)))^
 }
 MonsterDataViewerHitbox :: #force_inline proc(x: ^MonsterDataViewer,) -> []f64 #no_bounds_check {
-    if 50 + 40 > MonsterDataViewerSize(x) {
+    if 38 + 40 > MonsterDataViewerSize(x) {
         return []f64{}
     }
     slice := [2]int{ 0, 5}
-    (cast(^rawptr)(&slice[0]))^ = rawptr(mem.ptr_offset(cast([^]u8)(x), 50))
+    (cast(^rawptr)(&slice[0]))^ = rawptr(mem.ptr_offset(cast([^]u8)(x), 38))
 
     return ((^[]f64)(&slice))^
 }
 MonsterDataViewerStatus :: #force_inline proc(x: ^MonsterDataViewer,reader: ^karmem.Reader) -> []i32 #no_bounds_check {
-    if 90 + 12 > MonsterDataViewerSize(x) {
+    if 78 + 8 > MonsterDataViewerSize(x) {
         return []i32{}
     }
-    offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 90)))^
-    size := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 90 + 4)))^
+    offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 78)))^
+    size := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 78 + 4)))^
     if karmem.ReaderIsValidOffset(reader, offset, size) == false {
         return []i32{}
     }
@@ -696,24 +691,24 @@ MonsterDataViewerStatus :: #force_inline proc(x: ^MonsterDataViewer,reader: ^kar
     return (cast(^[]i32)(&slice))^
 }
 MonsterDataViewerWeapons :: #force_inline proc(x: ^MonsterDataViewer,) -> []WeaponViewer #no_bounds_check {
-    if 102 + 32 > MonsterDataViewerSize(x) {
+    if 86 + 16 > MonsterDataViewerSize(x) {
         return []WeaponViewer{}
     }
     slice := [2]int{ 0, 4}
-    (cast(^rawptr)(&slice[0]))^ = rawptr(mem.ptr_offset(cast([^]u8)(x), 102))
+    (cast(^rawptr)(&slice[0]))^ = rawptr(mem.ptr_offset(cast([^]u8)(x), 86))
 
     return ((^[]WeaponViewer)(&slice))^
 }
 MonsterDataViewerPath :: #force_inline proc(x: ^MonsterDataViewer,reader: ^karmem.Reader) -> []Vec3Viewer #no_bounds_check {
-    if 134 + 12 > MonsterDataViewerSize(x) {
+    if 102 + 8 > MonsterDataViewerSize(x) {
         return []Vec3Viewer{}
     }
-    offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 134)))^
-    size := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 134 + 4)))^
+    offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 102)))^
+    size := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 102 + 4)))^
     if karmem.ReaderIsValidOffset(reader, offset, size) == false {
         return []Vec3Viewer{}
     }
-    length := uint(size / 16)
+    length := uint(size / 12)
     if length > 2000 {
         length = 2000
     }
@@ -725,17 +720,17 @@ MonsterDataViewerPath :: #force_inline proc(x: ^MonsterDataViewer,reader: ^karme
     return (cast(^[]Vec3Viewer)(&slice))^
 }
 MonsterDataViewerIsAlive :: #force_inline proc(x: ^MonsterDataViewer,) -> bool #no_bounds_check {
-    if 146 + 1 > MonsterDataViewerSize(x) {
+    if 110 + 1 > MonsterDataViewerSize(x) {
         return false
     }
-    return ((^bool)(mem.ptr_offset(cast([^]u8)(x), 146)))^
+    return ((^bool)(mem.ptr_offset(cast([^]u8)(x), 110)))^
 }
 MonsterViewer :: struct #packed {
-    _data: [8]byte
+    _data: [4]byte
 }
 
 NewMonsterViewer :: #force_inline proc(reader: ^karmem.Reader, offset: u32) -> ^MonsterViewer  #no_bounds_check {
-    if karmem.ReaderIsValidOffset(reader, offset, 8) == false {
+    if karmem.ReaderIsValidOffset(reader, offset, 4) == false {
         return (^MonsterViewer)(&_Null)
     }
     v := cast(^MonsterViewer)(mem.ptr_offset(cast([^]u8)(reader.pointer), offset))
@@ -743,18 +738,18 @@ NewMonsterViewer :: #force_inline proc(reader: ^karmem.Reader, offset: u32) -> ^
 }
 
 MonsterViewerSize :: #force_inline proc(x: ^MonsterViewer) -> u32 #no_bounds_check {
-    return 8
+    return 4
 }
 MonsterViewerData :: #force_inline proc(x: ^MonsterViewer,reader: ^karmem.Reader) -> ^MonsterDataViewer #no_bounds_check {
     offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 0)))^
     return NewMonsterDataViewer(reader, offset)
 }
 MonstersViewer :: struct #packed {
-    _data: [24]byte
+    _data: [12]byte
 }
 
 NewMonstersViewer :: #force_inline proc(reader: ^karmem.Reader, offset: u32) -> ^MonstersViewer  #no_bounds_check {
-    if karmem.ReaderIsValidOffset(reader, offset, 8) == false {
+    if karmem.ReaderIsValidOffset(reader, offset, 4) == false {
         return (^MonstersViewer)(&_Null)
     }
     v := cast(^MonstersViewer)(mem.ptr_offset(cast([^]u8)(reader.pointer), offset))
@@ -768,7 +763,7 @@ MonstersViewerSize :: #force_inline proc(x: ^MonstersViewer) -> u32 #no_bounds_c
     return ((^u32)(x))^
 }
 MonstersViewerMonsters :: #force_inline proc(x: ^MonstersViewer,reader: ^karmem.Reader) -> []MonsterViewer #no_bounds_check {
-    if 4 + 12 > MonstersViewerSize(x) {
+    if 4 + 8 > MonstersViewerSize(x) {
         return []MonsterViewer{}
     }
     offset := ((^u32)(mem.ptr_offset(cast([^]u8)(x), 4)))^
@@ -776,7 +771,7 @@ MonstersViewerMonsters :: #force_inline proc(x: ^MonstersViewer,reader: ^karmem.
     if karmem.ReaderIsValidOffset(reader, offset, size) == false {
         return []MonsterViewer{}
     }
-    length := uint(size / 8)
+    length := uint(size / 4)
     if length > 2000 {
         length = 2000
     }

--- a/benchmark/km/game_generated.swift
+++ b/benchmark/km/game_generated.swift
@@ -88,6 +88,9 @@ public func NewVec3() -> Vec3 {
 
 public struct WeaponData {
     public var Damage: Int32 = 0
+    public var Ammo: UInt16 = 0
+    public var ClipSize: UInt8 = 0
+    public var ReloadTime: Float = 0
     public var Range: Int32 = 0
 
     public init() {}
@@ -98,6 +101,9 @@ public struct WeaponData {
 
     public mutating func Reset() -> () {
         self.Damage = 0
+        self.Ammo = 0
+        self.ClipSize = 0
+        self.ReloadTime = 0
         self.Range = 0
     }
 
@@ -108,17 +114,23 @@ public struct WeaponData {
 
     public mutating func Write(_ writer: inout karmem.Writer, _ start: UInt32) -> Bool {
         var offset = start
-        let size: UInt32 = 12
+        let size: UInt32 = 19
         if (offset == 0) {
             offset = writer.Alloc(size)
             if (offset == 0xFFFFFFFF) {
                 return false
             }
         }
-        writer.memory.storeBytes(of: UInt32(12), toByteOffset: Int(offset), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(19), toByteOffset: Int(offset), as: UInt32.self)
         let __DamageOffset: UInt32 = offset + 4
         writer.memory.storeBytes(of: self.Damage, toByteOffset: Int(__DamageOffset), as:Int32.self)
-        let __RangeOffset: UInt32 = offset + 8
+        let __AmmoOffset: UInt32 = offset + 8
+        writer.memory.storeBytes(of: self.Ammo, toByteOffset: Int(__AmmoOffset), as:UInt16.self)
+        let __ClipSizeOffset: UInt32 = offset + 10
+        writer.memory.storeBytes(of: self.ClipSize, toByteOffset: Int(__ClipSizeOffset), as:UInt8.self)
+        let __ReloadTimeOffset: UInt32 = offset + 11
+        writer.memory.storeBytes(of: self.ReloadTime, toByteOffset: Int(__ReloadTimeOffset), as:Float.self)
+        let __RangeOffset: UInt32 = offset + 15
         writer.memory.storeBytes(of: self.Range, toByteOffset: Int(__RangeOffset), as:Int32.self)
 
         return true
@@ -132,6 +144,9 @@ public struct WeaponData {
     @inline(__always)
     public mutating func Read(_ viewer: WeaponDataViewer, _ reader: karmem.Reader) -> () {
     self.Damage = viewer.Damage()
+    self.Ammo = viewer.Ammo()
+    self.ClipSize = viewer.ClipSize()
+    self.ReloadTime = viewer.ReloadTime()
     self.Range = viewer.Range()
     }
 
@@ -168,7 +183,7 @@ public struct Weapon {
                 return false
             }
         }
-        let __DataSize: UInt32 = 12
+        let __DataSize: UInt32 = 19
         let __DataOffset = writer.Alloc(__DataSize)
         if (__DataOffset == 0) {
             return false
@@ -644,11 +659,32 @@ public struct WeaponDataViewer : karmem.StructureViewer {
         return (self.karmemPointer + 4).loadUnaligned(as: Int32.self)
     }
     @inline(__always)
-    public func Range() -> Int32 {
-        if ((UInt32(8) + UInt32(4)) > self.SizeOf()) {
+    public func Ammo() -> UInt16 {
+        if ((UInt32(8) + UInt32(2)) > self.SizeOf()) {
             return 0
         }
-        return (self.karmemPointer + 8).loadUnaligned(as: Int32.self)
+        return (self.karmemPointer + 8).loadUnaligned(as: UInt16.self)
+    }
+    @inline(__always)
+    public func ClipSize() -> UInt8 {
+        if ((UInt32(10) + UInt32(1)) > self.SizeOf()) {
+            return 0
+        }
+        return (self.karmemPointer + 10).loadUnaligned(as: UInt8.self)
+    }
+    @inline(__always)
+    public func ReloadTime() -> Float {
+        if ((UInt32(11) + UInt32(4)) > self.SizeOf()) {
+            return 0
+        }
+        return (self.karmemPointer + 11).loadUnaligned(as: Float.self)
+    }
+    @inline(__always)
+    public func Range() -> Int32 {
+        if ((UInt32(15) + UInt32(4)) > self.SizeOf()) {
+            return 0
+        }
+        return (self.karmemPointer + 15).loadUnaligned(as: Int32.self)
     }
 }
 

--- a/benchmark/km/game_generated.swift
+++ b/benchmark/km/game_generated.swift
@@ -1,7 +1,7 @@
 
 import karmem
 
-var _Null : [UInt8] = Array(repeating: 0, count: 152)
+var _Null : [UInt8] = Array(repeating: 0, count: 111)
 var _NullReader = karmem.NewReader(_Null)
 
 public typealias EnumColor = UInt8
@@ -51,7 +51,7 @@ public struct Vec3 {
 
     public mutating func Write(_ writer: inout karmem.Writer, _ start: UInt32) -> Bool {
         var offset = start
-        let size: UInt32 = 16
+        let size: UInt32 = 12
         if (offset == 0) {
             offset = writer.Alloc(size)
             if (offset == 0xFFFFFFFF) {
@@ -108,7 +108,7 @@ public struct WeaponData {
 
     public mutating func Write(_ writer: inout karmem.Writer, _ start: UInt32) -> Bool {
         var offset = start
-        let size: UInt32 = 16
+        let size: UInt32 = 12
         if (offset == 0) {
             offset = writer.Alloc(size)
             if (offset == 0xFFFFFFFF) {
@@ -161,14 +161,14 @@ public struct Weapon {
 
     public mutating func Write(_ writer: inout karmem.Writer, _ start: UInt32) -> Bool {
         var offset = start
-        let size: UInt32 = 8
+        let size: UInt32 = 4
         if (offset == 0) {
             offset = writer.Alloc(size)
             if (offset == 0xFFFFFFFF) {
                 return false
             }
         }
-        let __DataSize: UInt32 = 16
+        let __DataSize: UInt32 = 12
         let __DataOffset = writer.Alloc(__DataSize)
         if (__DataOffset == 0) {
             return false
@@ -239,30 +239,29 @@ public struct MonsterData {
 
     public mutating func Write(_ writer: inout karmem.Writer, _ start: UInt32) -> Bool {
         var offset = start
-        let size: UInt32 = 152
+        let size: UInt32 = 111
         if (offset == 0) {
             offset = writer.Alloc(size)
             if (offset == 0xFFFFFFFF) {
                 return false
             }
         }
-        writer.memory.storeBytes(of: UInt32(147), toByteOffset: Int(offset), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(111), toByteOffset: Int(offset), as: UInt32.self)
         let __PosOffset: UInt32 = offset + 4
         if (!self.Pos.Write(&writer, __PosOffset)) {
             return false
         }
-        let __ManaOffset: UInt32 = offset + 20
+        let __ManaOffset: UInt32 = offset + 16
         writer.memory.storeBytes(of: self.Mana, toByteOffset: Int(__ManaOffset), as:Int16.self)
-        let __HealthOffset: UInt32 = offset + 22
+        let __HealthOffset: UInt32 = offset + 18
         writer.memory.storeBytes(of: self.Health, toByteOffset: Int(__HealthOffset), as:Int16.self)
         let __NameSize: UInt32 = 1 * UInt32(self.Name.count)
         let __NameOffset = writer.Alloc(__NameSize)
         if (__NameOffset == 0) {
             return false
         }
-        writer.memory.storeBytes(of: UInt32(__NameOffset), toByteOffset: Int(offset + 24), as: UInt32.self)
-        writer.memory.storeBytes(of: UInt32(__NameSize), toByteOffset: Int(offset + 24 + 4), as: UInt32.self)
-        writer.memory.storeBytes(of: UInt32(1), toByteOffset: Int(offset + 24 + 4 + 4), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(__NameOffset), toByteOffset: Int(offset + 20), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(__NameSize), toByteOffset: Int(offset + 20 + 4), as: UInt32.self)
         var __NameIndex = 0
         var __NameCurrentOffset = __NameOffset
         while(__NameIndex < self.Name.count) {
@@ -270,16 +269,15 @@ public struct MonsterData {
             __NameIndex = __NameIndex + 1
             __NameCurrentOffset = __NameCurrentOffset + 1
         }
-        let __TeamOffset: UInt32 = offset + 36
+        let __TeamOffset: UInt32 = offset + 28
         writer.memory.storeBytes(of: self.Team, toByteOffset: Int(__TeamOffset), as:EnumTeam.self)
         let __InventorySize: UInt32 = 1 * UInt32(self.Inventory.count)
         let __InventoryOffset = writer.Alloc(__InventorySize)
         if (__InventoryOffset == 0) {
             return false
         }
-        writer.memory.storeBytes(of: UInt32(__InventoryOffset), toByteOffset: Int(offset + 37), as: UInt32.self)
-        writer.memory.storeBytes(of: UInt32(__InventorySize), toByteOffset: Int(offset + 37 + 4), as: UInt32.self)
-        writer.memory.storeBytes(of: UInt32(1), toByteOffset: Int(offset + 37 + 4 + 4), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(__InventoryOffset), toByteOffset: Int(offset + 29), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(__InventorySize), toByteOffset: Int(offset + 29 + 4), as: UInt32.self)
         var __InventoryIndex = 0
         var __InventoryCurrentOffset = __InventoryOffset
         while(__InventoryIndex < self.Inventory.count) {
@@ -287,9 +285,9 @@ public struct MonsterData {
             __InventoryIndex = __InventoryIndex + 1
             __InventoryCurrentOffset = __InventoryCurrentOffset + 1
         }
-        let __ColorOffset: UInt32 = offset + 49
+        let __ColorOffset: UInt32 = offset + 37
         writer.memory.storeBytes(of: self.Color, toByteOffset: Int(__ColorOffset), as:EnumColor.self)
-        let __HitboxOffset: UInt32 = offset + 50
+        let __HitboxOffset: UInt32 = offset + 38
         var __HitboxIndex = 0
         var __HitboxCurrentOffset = __HitboxOffset
         while(__HitboxIndex < self.Hitbox.count) {
@@ -302,9 +300,8 @@ public struct MonsterData {
         if (__StatusOffset == 0) {
             return false
         }
-        writer.memory.storeBytes(of: UInt32(__StatusOffset), toByteOffset: Int(offset + 90), as: UInt32.self)
-        writer.memory.storeBytes(of: UInt32(__StatusSize), toByteOffset: Int(offset + 90 + 4), as: UInt32.self)
-        writer.memory.storeBytes(of: UInt32(4), toByteOffset: Int(offset + 90 + 4 + 4), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(__StatusOffset), toByteOffset: Int(offset + 78), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(__StatusSize), toByteOffset: Int(offset + 78 + 4), as: UInt32.self)
         var __StatusIndex = 0
         var __StatusCurrentOffset = __StatusOffset
         while(__StatusIndex < self.Status.count) {
@@ -312,32 +309,31 @@ public struct MonsterData {
             __StatusIndex = __StatusIndex + 1
             __StatusCurrentOffset = __StatusCurrentOffset + 4
         }
-        let __WeaponsOffset: UInt32 = offset + 102
+        let __WeaponsOffset: UInt32 = offset + 86
         let __WeaponsLen = self.Weapons.count
         var __WeaponsIndex = 0
         while (__WeaponsIndex < __WeaponsLen) {
-            if (!self.Weapons[__WeaponsIndex].Write(&writer, __WeaponsOffset + (UInt32(__WeaponsIndex) * 8))) {
+            if (!self.Weapons[__WeaponsIndex].Write(&writer, __WeaponsOffset + (UInt32(__WeaponsIndex) * 4))) {
                 return false
             }
             __WeaponsIndex = __WeaponsIndex + 1
         }
-        let __PathSize: UInt32 = 16 * UInt32(self.Path.count)
+        let __PathSize: UInt32 = 12 * UInt32(self.Path.count)
         let __PathOffset = writer.Alloc(__PathSize)
         if (__PathOffset == 0) {
             return false
         }
-        writer.memory.storeBytes(of: UInt32(__PathOffset), toByteOffset: Int(offset + 134), as: UInt32.self)
-        writer.memory.storeBytes(of: UInt32(__PathSize), toByteOffset: Int(offset + 134 + 4), as: UInt32.self)
-        writer.memory.storeBytes(of: UInt32(16), toByteOffset: Int(offset + 134 + 4 + 4), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(__PathOffset), toByteOffset: Int(offset + 102), as: UInt32.self)
+        writer.memory.storeBytes(of: UInt32(__PathSize), toByteOffset: Int(offset + 102 + 4), as: UInt32.self)
         let __PathLen = self.Path.count
         var __PathIndex = 0
         while (__PathIndex < __PathLen) {
-            if (!self.Path[__PathIndex].Write(&writer, __PathOffset + (UInt32(__PathIndex) * 16))) {
+            if (!self.Path[__PathIndex].Write(&writer, __PathOffset + (UInt32(__PathIndex) * 12))) {
                 return false
             }
             __PathIndex = __PathIndex + 1
         }
-        let __IsAliveOffset: UInt32 = offset + 146
+        let __IsAliveOffset: UInt32 = offset + 110
         writer.memory.storeBytes(of: self.IsAlive, toByteOffset: Int(__IsAliveOffset), as:Bool.self)
 
         return true
@@ -476,14 +472,14 @@ public struct Monster {
 
     public mutating func Write(_ writer: inout karmem.Writer, _ start: UInt32) -> Bool {
         var offset = start
-        let size: UInt32 = 8
+        let size: UInt32 = 4
         if (offset == 0) {
             offset = writer.Alloc(size)
             if (offset == 0xFFFFFFFF) {
                 return false
             }
         }
-        let __DataSize: UInt32 = 152
+        let __DataSize: UInt32 = 111
         let __DataOffset = writer.Alloc(__DataSize)
         if (__DataOffset == 0) {
             return false
@@ -532,26 +528,25 @@ public struct Monsters {
 
     public mutating func Write(_ writer: inout karmem.Writer, _ start: UInt32) -> Bool {
         var offset = start
-        let size: UInt32 = 24
+        let size: UInt32 = 12
         if (offset == 0) {
             offset = writer.Alloc(size)
             if (offset == 0xFFFFFFFF) {
                 return false
             }
         }
-        writer.memory.storeBytes(of: UInt32(16), toByteOffset: Int(offset), as: UInt32.self)
-        let __MonstersSize: UInt32 = 8 * UInt32(self.Monsters.count)
+        writer.memory.storeBytes(of: UInt32(12), toByteOffset: Int(offset), as: UInt32.self)
+        let __MonstersSize: UInt32 = 4 * UInt32(self.Monsters.count)
         let __MonstersOffset = writer.Alloc(__MonstersSize)
         if (__MonstersOffset == 0) {
             return false
         }
         writer.memory.storeBytes(of: UInt32(__MonstersOffset), toByteOffset: Int(offset + 4), as: UInt32.self)
         writer.memory.storeBytes(of: UInt32(__MonstersSize), toByteOffset: Int(offset + 4 + 4), as: UInt32.self)
-        writer.memory.storeBytes(of: UInt32(8), toByteOffset: Int(offset + 4 + 4 + 4), as: UInt32.self)
         let __MonstersLen = self.Monsters.count
         var __MonstersIndex = 0
         while (__MonstersIndex < __MonstersLen) {
-            if (!self.Monsters[__MonstersIndex].Write(&writer, __MonstersOffset + (UInt32(__MonstersIndex) * 8))) {
+            if (!self.Monsters[__MonstersIndex].Write(&writer, __MonstersOffset + (UInt32(__MonstersIndex) * 4))) {
                 return false
             }
             __MonstersIndex = __MonstersIndex + 1
@@ -603,7 +598,7 @@ public struct Vec3Viewer : karmem.StructureViewer {
 
     @inline(__always)
     public func SizeOf() -> UInt32 {
-        return 16
+        return 12
     }
     @inline(__always)
     public func X() -> Float {
@@ -620,7 +615,7 @@ public struct Vec3Viewer : karmem.StructureViewer {
 }
 
 @inline(__always) public func NewVec3Viewer(_ reader: karmem.Reader, _ offset: UInt32) -> Vec3Viewer {
-    if (!reader.IsValidOffset(offset, 16)) {
+    if (!reader.IsValidOffset(offset, 12)) {
         return Vec3Viewer(ptr: _Null.withUnsafeBufferPointer({ return UnsafePointer($0.baseAddress!) }))
     }
 
@@ -658,7 +653,7 @@ public struct WeaponDataViewer : karmem.StructureViewer {
 }
 
 @inline(__always) public func NewWeaponDataViewer(_ reader: karmem.Reader, _ offset: UInt32) -> WeaponDataViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return WeaponDataViewer(ptr: _Null.withUnsafeBufferPointer({ return UnsafePointer($0.baseAddress!) }))
     }
 
@@ -680,7 +675,7 @@ public struct WeaponViewer : karmem.StructureViewer {
 
     @inline(__always)
     public func SizeOf() -> UInt32 {
-        return 8
+        return 4
     }
     @inline(__always)
     public func Data(_ reader: karmem.Reader) -> WeaponDataViewer {
@@ -690,7 +685,7 @@ public struct WeaponViewer : karmem.StructureViewer {
 }
 
 @inline(__always) public func NewWeaponViewer(_ reader: karmem.Reader, _ offset: UInt32) -> WeaponViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return WeaponViewer(ptr: _Null.withUnsafeBufferPointer({ return UnsafePointer($0.baseAddress!) }))
     }
 
@@ -713,32 +708,32 @@ public struct MonsterDataViewer : karmem.StructureViewer {
     }
     @inline(__always)
     public func Pos() -> Vec3Viewer {
-        if ((UInt32(4) + UInt32(16)) > self.SizeOf()) {
+        if ((UInt32(4) + UInt32(12)) > self.SizeOf()) {
             return Vec3Viewer(ptr: _Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }))
         }
         return  Vec3Viewer(ptr: self.karmemPointer + 4)
     }
     @inline(__always)
     public func Mana() -> Int16 {
-        if ((UInt32(20) + UInt32(2)) > self.SizeOf()) {
+        if ((UInt32(16) + UInt32(2)) > self.SizeOf()) {
             return 0
         }
-        return (self.karmemPointer + 20).loadUnaligned(as: Int16.self)
+        return (self.karmemPointer + 16).loadUnaligned(as: Int16.self)
     }
     @inline(__always)
     public func Health() -> Int16 {
-        if ((UInt32(22) + UInt32(2)) > self.SizeOf()) {
+        if ((UInt32(18) + UInt32(2)) > self.SizeOf()) {
             return 0
         }
-        return (self.karmemPointer + 22).loadUnaligned(as: Int16.self)
+        return (self.karmemPointer + 18).loadUnaligned(as: Int16.self)
     }
     @inline(__always)
     public func Name(_ reader: karmem.Reader) -> karmem.Slice<UInt8> {
-        if ((UInt32(24) + UInt32(12)) > self.SizeOf()) {
+        if ((UInt32(20) + UInt32(8)) > self.SizeOf()) {
                 return karmem.NewSliceUnaligned(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: UInt8.self)
         }
-        let offset = (self.karmemPointer + 24).loadUnaligned(as: UInt32.self)
-        let size = (self.karmemPointer + 24 + 4).loadUnaligned(as: UInt32.self)
+        let offset = (self.karmemPointer + 20).loadUnaligned(as: UInt32.self)
+        let size = (self.karmemPointer + 20 + 4).loadUnaligned(as: UInt32.self)
         if (!reader.IsValidOffset(offset, size)) {
                 return karmem.NewSliceUnaligned(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: UInt8.self)
         }
@@ -751,18 +746,18 @@ public struct MonsterDataViewer : karmem.StructureViewer {
     }
     @inline(__always)
     public func Team() -> EnumTeam {
-        if ((UInt32(36) + UInt32(1)) > self.SizeOf()) {
+        if ((UInt32(28) + UInt32(1)) > self.SizeOf()) {
             return 0
         }
-        return (self.karmemPointer + 36).loadUnaligned(as: EnumTeam.self)
+        return (self.karmemPointer + 28).loadUnaligned(as: EnumTeam.self)
     }
     @inline(__always)
     public func Inventory(_ reader: karmem.Reader) -> karmem.Slice<UInt8> {
-        if ((UInt32(37) + UInt32(12)) > self.SizeOf()) {
+        if ((UInt32(29) + UInt32(8)) > self.SizeOf()) {
                 return karmem.NewSliceUnaligned(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: UInt8.self)
         }
-        let offset = (self.karmemPointer + 37).loadUnaligned(as: UInt32.self)
-        let size = (self.karmemPointer + 37 + 4).loadUnaligned(as: UInt32.self)
+        let offset = (self.karmemPointer + 29).loadUnaligned(as: UInt32.self)
+        let size = (self.karmemPointer + 29 + 4).loadUnaligned(as: UInt32.self)
         if (!reader.IsValidOffset(offset, size)) {
                 return karmem.NewSliceUnaligned(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: UInt8.self)
         }
@@ -775,25 +770,25 @@ public struct MonsterDataViewer : karmem.StructureViewer {
     }
     @inline(__always)
     public func Color() -> EnumColor {
-        if ((UInt32(49) + UInt32(1)) > self.SizeOf()) {
+        if ((UInt32(37) + UInt32(1)) > self.SizeOf()) {
             return 0
         }
-        return (self.karmemPointer + 49).loadUnaligned(as: EnumColor.self)
+        return (self.karmemPointer + 37).loadUnaligned(as: EnumColor.self)
     }
     @inline(__always)
     public func Hitbox() -> karmem.Slice<Double> {
-        if ((UInt32(50) + UInt32(40)) > self.SizeOf()) {
+        if ((UInt32(38) + UInt32(40)) > self.SizeOf()) {
                 return karmem.NewSliceUnaligned(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: Double.self)
         }
-        return karmem.NewSliceUnaligned(UnsafeRawPointer(self.karmemPointer + Int(50)), 5, 8, as: Double.self)
+        return karmem.NewSliceUnaligned(UnsafeRawPointer(self.karmemPointer + Int(38)), 5, 8, as: Double.self)
     }
     @inline(__always)
     public func Status(_ reader: karmem.Reader) -> karmem.Slice<Int32> {
-        if ((UInt32(90) + UInt32(12)) > self.SizeOf()) {
+        if ((UInt32(78) + UInt32(8)) > self.SizeOf()) {
                 return karmem.NewSliceUnaligned(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: Int32.self)
         }
-        let offset = (self.karmemPointer + 90).loadUnaligned(as: UInt32.self)
-        let size = (self.karmemPointer + 90 + 4).loadUnaligned(as: UInt32.self)
+        let offset = (self.karmemPointer + 78).loadUnaligned(as: UInt32.self)
+        let size = (self.karmemPointer + 78 + 4).loadUnaligned(as: UInt32.self)
         if (!reader.IsValidOffset(offset, size)) {
                 return karmem.NewSliceUnaligned(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as: Int32.self)
         }
@@ -806,39 +801,39 @@ public struct MonsterDataViewer : karmem.StructureViewer {
     }
     @inline(__always)
     public func Weapons() -> karmem.SliceStructure<WeaponViewer> {
-        if ((UInt32(102) + UInt32(32)) > self.SizeOf()) {
+        if ((UInt32(86) + UInt32(16)) > self.SizeOf()) {
                 return karmem.NewSliceStructure(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as:WeaponViewer.self)
         }
-        return karmem.NewSliceStructure(UnsafeRawPointer(self.karmemPointer + Int(102)), 4, 8, as:WeaponViewer.self)
+        return karmem.NewSliceStructure(UnsafeRawPointer(self.karmemPointer + Int(86)), 4, 4, as:WeaponViewer.self)
     }
     @inline(__always)
     public func Path(_ reader: karmem.Reader) -> karmem.SliceStructure<Vec3Viewer> {
-        if ((UInt32(134) + UInt32(12)) > self.SizeOf()) {
+        if ((UInt32(102) + UInt32(8)) > self.SizeOf()) {
                 return karmem.NewSliceStructure(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as:Vec3Viewer.self)
         }
-        let offset = (self.karmemPointer + 134).loadUnaligned(as: UInt32.self)
-        let size = (self.karmemPointer + 134 + 4).loadUnaligned(as: UInt32.self)
+        let offset = (self.karmemPointer + 102).loadUnaligned(as: UInt32.self)
+        let size = (self.karmemPointer + 102 + 4).loadUnaligned(as: UInt32.self)
         if (!reader.IsValidOffset(offset, size)) {
                 return karmem.NewSliceStructure(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as:Vec3Viewer.self)
         }
 
-        var length = size / 16
+        var length = size / 12
         if (length > 2000) {
             length = 2000
         }
-        return karmem.NewSliceStructure(UnsafeRawPointer(reader.pointer + Int(offset)), length, 16, as:Vec3Viewer.self)
+        return karmem.NewSliceStructure(UnsafeRawPointer(reader.pointer + Int(offset)), length, 12, as:Vec3Viewer.self)
     }
     @inline(__always)
     public func IsAlive() -> Bool {
-        if ((UInt32(146) + UInt32(1)) > self.SizeOf()) {
+        if ((UInt32(110) + UInt32(1)) > self.SizeOf()) {
             return false
         }
-        return (self.karmemPointer + 146).loadUnaligned(as: Bool.self)
+        return (self.karmemPointer + 110).loadUnaligned(as: Bool.self)
     }
 }
 
 @inline(__always) public func NewMonsterDataViewer(_ reader: karmem.Reader, _ offset: UInt32) -> MonsterDataViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return MonsterDataViewer(ptr: _Null.withUnsafeBufferPointer({ return UnsafePointer($0.baseAddress!) }))
     }
 
@@ -860,7 +855,7 @@ public struct MonsterViewer : karmem.StructureViewer {
 
     @inline(__always)
     public func SizeOf() -> UInt32 {
-        return 8
+        return 4
     }
     @inline(__always)
     public func Data(_ reader: karmem.Reader) -> MonsterDataViewer {
@@ -870,7 +865,7 @@ public struct MonsterViewer : karmem.StructureViewer {
 }
 
 @inline(__always) public func NewMonsterViewer(_ reader: karmem.Reader, _ offset: UInt32) -> MonsterViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return MonsterViewer(ptr: _Null.withUnsafeBufferPointer({ return UnsafePointer($0.baseAddress!) }))
     }
 
@@ -893,7 +888,7 @@ public struct MonstersViewer : karmem.StructureViewer {
     }
     @inline(__always)
     public func Monsters(_ reader: karmem.Reader) -> karmem.SliceStructure<MonsterViewer> {
-        if ((UInt32(4) + UInt32(12)) > self.SizeOf()) {
+        if ((UInt32(4) + UInt32(8)) > self.SizeOf()) {
                 return karmem.NewSliceStructure(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as:MonsterViewer.self)
         }
         let offset = (self.karmemPointer + 4).loadUnaligned(as: UInt32.self)
@@ -902,16 +897,16 @@ public struct MonstersViewer : karmem.StructureViewer {
                 return karmem.NewSliceStructure(_Null.withUnsafeBufferPointer({ return UnsafeRawPointer($0.baseAddress!) }), 0, 0, as:MonsterViewer.self)
         }
 
-        var length = size / 8
+        var length = size / 4
         if (length > 2000) {
             length = 2000
         }
-        return karmem.NewSliceStructure(UnsafeRawPointer(reader.pointer + Int(offset)), length, 8, as:MonsterViewer.self)
+        return karmem.NewSliceStructure(UnsafeRawPointer(reader.pointer + Int(offset)), length, 4, as:MonsterViewer.self)
     }
 }
 
 @inline(__always) public func NewMonstersViewer(_ reader: karmem.Reader, _ offset: UInt32) -> MonstersViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return MonstersViewer(ptr: _Null.withUnsafeBufferPointer({ return UnsafePointer($0.baseAddress!) }))
     }
 

--- a/benchmark/km/game_generated.ts
+++ b/benchmark/km/game_generated.ts
@@ -87,6 +87,9 @@ export function NewVec3(): Vec3 {
 
 export class WeaponData {
     Damage: i32;
+    Ammo: u16;
+    ClipSize: u8;
+    ReloadTime: f32;
     Range: i32;
 
     static PacketIdentifier() : PacketIdentifier {
@@ -104,17 +107,23 @@ export class WeaponData {
 
     static Write(x: WeaponData, writer: karmem.Writer, start: u32): boolean {
         let offset = start;
-        const size: u32 = 12;
+        const size: u32 = 19;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == 0xFFFFFFFF) {
                 return false;
             }
         }
-        writer.WriteAt<u32>(offset, 12);
+        writer.WriteAt<u32>(offset, 19);
         let __DamageOffset: u32 = offset + 4;
         writer.WriteAt<i32>(__DamageOffset, x.Damage);
-        let __RangeOffset: u32 = offset + 8;
+        let __AmmoOffset: u32 = offset + 8;
+        writer.WriteAt<u16>(__AmmoOffset, x.Ammo);
+        let __ClipSizeOffset: u32 = offset + 10;
+        writer.WriteAt<u8>(__ClipSizeOffset, x.ClipSize);
+        let __ReloadTimeOffset: u32 = offset + 11;
+        writer.WriteAt<f32>(__ReloadTimeOffset, x.ReloadTime);
+        let __RangeOffset: u32 = offset + 15;
         writer.WriteAt<i32>(__RangeOffset, x.Range);
 
         return true
@@ -128,6 +137,9 @@ export class WeaponData {
     @inline
     static Read(x: WeaponData, viewer: WeaponDataViewer, reader: karmem.Reader) : void {
     x.Damage = viewer.Damage();
+    x.Ammo = viewer.Ammo();
+    x.ClipSize = viewer.ClipSize();
+    x.ReloadTime = viewer.ReloadTime();
     x.Range = viewer.Range();
     }
 
@@ -136,6 +148,9 @@ export class WeaponData {
 export function NewWeaponData(): WeaponData {
     let x: WeaponData = {
     Damage: 0,
+    Ammo: 0,
+    ClipSize: 0,
+    ReloadTime: 0,
     Range: 0,
     }
     return x;
@@ -166,7 +181,7 @@ export class Weapon {
                 return false;
             }
         }
-        const __DataSize: u32 = 12;
+        const __DataSize: u32 = 19;
         let __DataOffset = writer.Alloc(__DataSize);
         if (__DataOffset == 0) {
             return false;
@@ -571,7 +586,9 @@ export class Vec3Viewer {
 @unmanaged
 export class WeaponDataViewer {
     private _0: u64;
-    private _1: u32;
+    private _1: u64;
+    private _2: u16;
+    private _3: u8;
 
     @inline
     SizeOf(): u32 {
@@ -585,11 +602,32 @@ export class WeaponDataViewer {
         return load<i32>(changetype<usize>(this) + 4);
     }
     @inline
-    Range(): i32 {
-        if ((<u32>8 + <u32>4) > this.SizeOf()) {
+    Ammo(): u16 {
+        if ((<u32>8 + <u32>2) > this.SizeOf()) {
             return 0
         }
-        return load<i32>(changetype<usize>(this) + 8);
+        return load<u16>(changetype<usize>(this) + 8);
+    }
+    @inline
+    ClipSize(): u8 {
+        if ((<u32>10 + <u32>1) > this.SizeOf()) {
+            return 0
+        }
+        return load<u8>(changetype<usize>(this) + 10);
+    }
+    @inline
+    ReloadTime(): f32 {
+        if ((<u32>11 + <u32>4) > this.SizeOf()) {
+            return 0
+        }
+        return load<f32>(changetype<usize>(this) + 11);
+    }
+    @inline
+    Range(): i32 {
+        if ((<u32>15 + <u32>4) > this.SizeOf()) {
+            return 0
+        }
+        return load<i32>(changetype<usize>(this) + 15);
     }
 }
 

--- a/benchmark/km/game_generated.ts
+++ b/benchmark/km/game_generated.ts
@@ -1,7 +1,7 @@
 
 import * as karmem from '../../assemblyscript/karmem'
 
-let _Null = new StaticArray<u8>(152)
+let _Null = new StaticArray<u8>(111)
 let _NullReader = karmem.NewReader(_Null)
 
 export type Color = u8;
@@ -45,7 +45,7 @@ export class Vec3 {
 
     static Write(x: Vec3, writer: karmem.Writer, start: u32): boolean {
         let offset = start;
-        const size: u32 = 16;
+        const size: u32 = 12;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == 0xFFFFFFFF) {
@@ -104,7 +104,7 @@ export class WeaponData {
 
     static Write(x: WeaponData, writer: karmem.Writer, start: u32): boolean {
         let offset = start;
-        const size: u32 = 16;
+        const size: u32 = 12;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == 0xFFFFFFFF) {
@@ -159,14 +159,14 @@ export class Weapon {
 
     static Write(x: Weapon, writer: karmem.Writer, start: u32): boolean {
         let offset = start;
-        const size: u32 = 8;
+        const size: u32 = 4;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == 0xFFFFFFFF) {
                 return false;
             }
         }
-        const __DataSize: u32 = 16;
+        const __DataSize: u32 = 12;
         let __DataOffset = writer.Alloc(__DataSize);
         if (__DataOffset == 0) {
             return false;
@@ -227,21 +227,21 @@ export class MonsterData {
 
     static Write(x: MonsterData, writer: karmem.Writer, start: u32): boolean {
         let offset = start;
-        const size: u32 = 152;
+        const size: u32 = 111;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == 0xFFFFFFFF) {
                 return false;
             }
         }
-        writer.WriteAt<u32>(offset, 147);
+        writer.WriteAt<u32>(offset, 111);
         let __PosOffset: u32 = offset + 4;
         if (!Vec3.Write(x.Pos, writer, __PosOffset)) {
             return false;
         }
-        let __ManaOffset: u32 = offset + 20;
+        let __ManaOffset: u32 = offset + 16;
         writer.WriteAt<i16>(__ManaOffset, x.Mana);
-        let __HealthOffset: u32 = offset + 22;
+        let __HealthOffset: u32 = offset + 18;
         writer.WriteAt<i16>(__HealthOffset, x.Health);
         const __NameString : Uint8Array = Uint8Array.wrap(String.UTF8.encode(x.Name, false))
         const __NameSize: u32 = 1 * __NameString.length;
@@ -249,58 +249,54 @@ export class MonsterData {
         if (__NameOffset == 0) {
             return false;
         }
-        writer.WriteAt<u32>(offset +24, __NameOffset);
-        writer.WriteAt<u32>(offset +24 +4, __NameSize);
-        writer.WriteAt<u32>(offset + 24 + 4 + 4, 1)
+        writer.WriteAt<u32>(offset +20, __NameOffset);
+        writer.WriteAt<u32>(offset +20 +4, __NameSize);
         writer.WriteSliceAt<Uint8Array>(__NameOffset, __NameString);
-        let __TeamOffset: u32 = offset + 36;
+        let __TeamOffset: u32 = offset + 28;
         writer.WriteAt<Team>(__TeamOffset, x.Team);
         const __InventorySize: u32 = 1 * x.Inventory.length;
         let __InventoryOffset = writer.Alloc(__InventorySize);
         if (__InventoryOffset == 0) {
             return false;
         }
-        writer.WriteAt<u32>(offset +37, __InventoryOffset);
-        writer.WriteAt<u32>(offset +37 +4, __InventorySize);
-        writer.WriteAt<u32>(offset + 37 + 4 + 4, 1)
+        writer.WriteAt<u32>(offset +29, __InventoryOffset);
+        writer.WriteAt<u32>(offset +29 +4, __InventorySize);
         writer.WriteSliceAt<Array<u8>>(__InventoryOffset, x.Inventory);
-        let __ColorOffset: u32 = offset + 49;
+        let __ColorOffset: u32 = offset + 37;
         writer.WriteAt<Color>(__ColorOffset, x.Color);
-        let __HitboxOffset: u32 = offset + 50;
+        let __HitboxOffset: u32 = offset + 38;
         writer.WriteArrayAt<StaticArray<f64>>(__HitboxOffset, x.Hitbox);
         const __StatusSize: u32 = 4 * x.Status.length;
         let __StatusOffset = writer.Alloc(__StatusSize);
         if (__StatusOffset == 0) {
             return false;
         }
-        writer.WriteAt<u32>(offset +90, __StatusOffset);
-        writer.WriteAt<u32>(offset +90 +4, __StatusSize);
-        writer.WriteAt<u32>(offset + 90 + 4 + 4, 4)
+        writer.WriteAt<u32>(offset +78, __StatusOffset);
+        writer.WriteAt<u32>(offset +78 +4, __StatusSize);
         writer.WriteSliceAt<Array<i32>>(__StatusOffset, x.Status);
-        let __WeaponsOffset: u32 = offset + 102;
+        let __WeaponsOffset: u32 = offset + 86;
         let __WeaponsLen = x.Weapons.length;
         for (let i = 0; i < __WeaponsLen; i++) {
             if (!Weapon.Write(x.Weapons[i], writer, __WeaponsOffset)) {
                 return false;
             }
-            __WeaponsOffset += 8;
+            __WeaponsOffset += 4;
         }
-        const __PathSize: u32 = 16 * x.Path.length;
+        const __PathSize: u32 = 12 * x.Path.length;
         let __PathOffset = writer.Alloc(__PathSize);
         if (__PathOffset == 0) {
             return false;
         }
-        writer.WriteAt<u32>(offset +134, __PathOffset);
-        writer.WriteAt<u32>(offset +134 +4, __PathSize);
-        writer.WriteAt<u32>(offset + 134 + 4 + 4, 16)
+        writer.WriteAt<u32>(offset +102, __PathOffset);
+        writer.WriteAt<u32>(offset +102 +4, __PathSize);
         let __PathLen = x.Path.length;
         for (let i = 0; i < __PathLen; i++) {
             if (!Vec3.Write(x.Path[i], writer, __PathOffset)) {
                 return false;
             }
-            __PathOffset += 16;
+            __PathOffset += 12;
         }
-        let __IsAliveOffset: u32 = offset + 146;
+        let __IsAliveOffset: u32 = offset + 110;
         writer.WriteAt<bool>(__IsAliveOffset, x.IsAlive);
 
         return true
@@ -427,14 +423,14 @@ export class Monster {
 
     static Write(x: Monster, writer: karmem.Writer, start: u32): boolean {
         let offset = start;
-        const size: u32 = 8;
+        const size: u32 = 4;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == 0xFFFFFFFF) {
                 return false;
             }
         }
-        const __DataSize: u32 = 152;
+        const __DataSize: u32 = 111;
         let __DataOffset = writer.Alloc(__DataSize);
         if (__DataOffset == 0) {
             return false;
@@ -484,28 +480,27 @@ export class Monsters {
 
     static Write(x: Monsters, writer: karmem.Writer, start: u32): boolean {
         let offset = start;
-        const size: u32 = 24;
+        const size: u32 = 12;
         if (offset == 0) {
             offset = writer.Alloc(size);
             if (offset == 0xFFFFFFFF) {
                 return false;
             }
         }
-        writer.WriteAt<u32>(offset, 16);
-        const __MonstersSize: u32 = 8 * x.Monsters.length;
+        writer.WriteAt<u32>(offset, 12);
+        const __MonstersSize: u32 = 4 * x.Monsters.length;
         let __MonstersOffset = writer.Alloc(__MonstersSize);
         if (__MonstersOffset == 0) {
             return false;
         }
         writer.WriteAt<u32>(offset +4, __MonstersOffset);
         writer.WriteAt<u32>(offset +4 +4, __MonstersSize);
-        writer.WriteAt<u32>(offset + 4 + 4 + 4, 8)
         let __MonstersLen = x.Monsters.length;
         for (let i = 0; i < __MonstersLen; i++) {
             if (!Monster.Write(x.Monsters[i], writer, __MonstersOffset)) {
                 return false;
             }
-            __MonstersOffset += 8;
+            __MonstersOffset += 4;
         }
 
         return true
@@ -545,11 +540,11 @@ export function NewMonsters(): Monsters {
 @unmanaged
 export class Vec3Viewer {
     private _0: u64;
-    private _1: u64;
+    private _1: u32;
 
     @inline
     SizeOf(): u32 {
-        return 16;
+        return 12;
     }
     @inline
     X(): f32 {
@@ -566,7 +561,7 @@ export class Vec3Viewer {
 }
 
 @inline export function NewVec3Viewer(reader: karmem.Reader, offset: u32): Vec3Viewer {
-    if (!reader.IsValidOffset(offset, 16)) {
+    if (!reader.IsValidOffset(offset, 12)) {
         return changetype<Vec3Viewer>(changetype<usize>(_Null))
     }
 
@@ -576,7 +571,7 @@ export class Vec3Viewer {
 @unmanaged
 export class WeaponDataViewer {
     private _0: u64;
-    private _1: u64;
+    private _1: u32;
 
     @inline
     SizeOf(): u32 {
@@ -599,7 +594,7 @@ export class WeaponDataViewer {
 }
 
 @inline export function NewWeaponDataViewer(reader: karmem.Reader, offset: u32): WeaponDataViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return changetype<WeaponDataViewer>(changetype<usize>(_Null))
     }
 
@@ -611,11 +606,11 @@ export class WeaponDataViewer {
 }
 @unmanaged
 export class WeaponViewer {
-    private _0: u64;
+    private _0: u32;
 
     @inline
     SizeOf(): u32 {
-        return 8;
+        return 4;
     }
     @inline
     Data(reader: karmem.Reader): WeaponDataViewer {
@@ -625,7 +620,7 @@ export class WeaponViewer {
 }
 
 @inline export function NewWeaponViewer(reader: karmem.Reader, offset: u32): WeaponViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return changetype<WeaponViewer>(changetype<usize>(_Null))
     }
 
@@ -647,12 +642,9 @@ export class MonsterDataViewer {
     private _10: u64;
     private _11: u64;
     private _12: u64;
-    private _13: u64;
-    private _14: u64;
-    private _15: u64;
-    private _16: u64;
-    private _17: u64;
-    private _18: u64;
+    private _13: u32;
+    private _14: u16;
+    private _15: u8;
 
     @inline
     SizeOf(): u32 {
@@ -660,32 +652,32 @@ export class MonsterDataViewer {
     }
     @inline
     Pos(): Vec3Viewer {
-        if ((<u32>4 + <u32>16) > this.SizeOf()) {
+        if ((<u32>4 + <u32>12) > this.SizeOf()) {
             return changetype<Vec3Viewer>(changetype<usize>(_Null));
         }
         return changetype<Vec3Viewer>(changetype<usize>(this) + 4);
     }
     @inline
     Mana(): i16 {
-        if ((<u32>20 + <u32>2) > this.SizeOf()) {
+        if ((<u32>16 + <u32>2) > this.SizeOf()) {
             return 0
         }
-        return load<i16>(changetype<usize>(this) + 20);
+        return load<i16>(changetype<usize>(this) + 16);
     }
     @inline
     Health(): i16 {
-        if ((<u32>22 + <u32>2) > this.SizeOf()) {
+        if ((<u32>18 + <u32>2) > this.SizeOf()) {
             return 0
         }
-        return load<i16>(changetype<usize>(this) + 22);
+        return load<i16>(changetype<usize>(this) + 18);
     }
     @inline
     Name(reader: karmem.Reader): string {
-        if ((<u32>24 + <u32>12) > this.SizeOf()) {
+        if ((<u32>20 + <u32>8) > this.SizeOf()) {
             return ""
         }
-        let offset: u32 = load<u32>(changetype<usize>(this) + 24);
-        let size: u32 = load<u32>(changetype<usize>(this) + 24 +4);
+        let offset: u32 = load<u32>(changetype<usize>(this) + 20);
+        let size: u32 = load<u32>(changetype<usize>(this) + 20 +4);
         if (!reader.IsValidOffset(offset, size)) {
             return "";
         }
@@ -693,18 +685,18 @@ export class MonsterDataViewer {
     }
     @inline
     Team(): Team {
-        if ((<u32>36 + <u32>1) > this.SizeOf()) {
+        if ((<u32>28 + <u32>1) > this.SizeOf()) {
             return 0
         }
-        return load<Team>(changetype<usize>(this) + 36);
+        return load<Team>(changetype<usize>(this) + 28);
     }
     @inline
     Inventory(reader: karmem.Reader): karmem.Slice<u8> {
-        if ((<u32>37 + <u32>12) > this.SizeOf()) {
+        if ((<u32>29 + <u32>8) > this.SizeOf()) {
             return new karmem.Slice<u8>(0,0,0)
         }
-        let offset: u32 = load<u32>(changetype<usize>(this) + 37);
-        let size: u32 = load<u32>(changetype<usize>(this) + 37 +4);
+        let offset: u32 = load<u32>(changetype<usize>(this) + 29);
+        let size: u32 = load<u32>(changetype<usize>(this) + 29 +4);
         if (!reader.IsValidOffset(offset, size)) {
             return new karmem.Slice<u8>(0, 0, 0);
         }
@@ -716,25 +708,25 @@ export class MonsterDataViewer {
     }
     @inline
     Color(): Color {
-        if ((<u32>49 + <u32>1) > this.SizeOf()) {
+        if ((<u32>37 + <u32>1) > this.SizeOf()) {
             return 0
         }
-        return load<Color>(changetype<usize>(this) + 49);
+        return load<Color>(changetype<usize>(this) + 37);
     }
     @inline
     Hitbox(): karmem.Slice<f64> {
-        if ((<u32>50 + <u32>40) > this.SizeOf()) {
+        if ((<u32>38 + <u32>40) > this.SizeOf()) {
             return new karmem.Slice<f64>(0,0,0)
         }
-        return new karmem.Slice<f64>(changetype<usize>(this) + 50, 5, 8);
+        return new karmem.Slice<f64>(changetype<usize>(this) + 38, 5, 8);
     }
     @inline
     Status(reader: karmem.Reader): karmem.Slice<i32> {
-        if ((<u32>90 + <u32>12) > this.SizeOf()) {
+        if ((<u32>78 + <u32>8) > this.SizeOf()) {
             return new karmem.Slice<i32>(0,0,0)
         }
-        let offset: u32 = load<u32>(changetype<usize>(this) + 90);
-        let size: u32 = load<u32>(changetype<usize>(this) + 90 +4);
+        let offset: u32 = load<u32>(changetype<usize>(this) + 78);
+        let size: u32 = load<u32>(changetype<usize>(this) + 78 +4);
         if (!reader.IsValidOffset(offset, size)) {
             return new karmem.Slice<i32>(0, 0, 0);
         }
@@ -746,38 +738,38 @@ export class MonsterDataViewer {
     }
     @inline
     Weapons(): karmem.Slice<WeaponViewer> {
-        if ((<u32>102 + <u32>32) > this.SizeOf()) {
+        if ((<u32>86 + <u32>16) > this.SizeOf()) {
             return new karmem.Slice<WeaponViewer>(0,0,0)
         }
-        return new karmem.Slice<WeaponViewer>(changetype<usize>(this) + 102, 4, 8);
+        return new karmem.Slice<WeaponViewer>(changetype<usize>(this) + 86, 4, 4);
     }
     @inline
     Path(reader: karmem.Reader): karmem.Slice<Vec3Viewer> {
-        if ((<u32>134 + <u32>12) > this.SizeOf()) {
+        if ((<u32>102 + <u32>8) > this.SizeOf()) {
             return new karmem.Slice<Vec3Viewer>(0,0,0)
         }
-        let offset: u32 = load<u32>(changetype<usize>(this) + 134);
-        let size: u32 = load<u32>(changetype<usize>(this) + 134 +4);
+        let offset: u32 = load<u32>(changetype<usize>(this) + 102);
+        let size: u32 = load<u32>(changetype<usize>(this) + 102 +4);
         if (!reader.IsValidOffset(offset, size)) {
             return new karmem.Slice<Vec3Viewer>(0, 0, 0);
         }
-        let length = size / 16;
+        let length = size / 12;
         if (length > 2000) {
             length = 2000;
         }
-        return new karmem.Slice<Vec3Viewer>(reader.Pointer + offset, length, 16);
+        return new karmem.Slice<Vec3Viewer>(reader.Pointer + offset, length, 12);
     }
     @inline
     IsAlive(): bool {
-        if ((<u32>146 + <u32>1) > this.SizeOf()) {
+        if ((<u32>110 + <u32>1) > this.SizeOf()) {
             return false
         }
-        return load<bool>(changetype<usize>(this) + 146);
+        return load<bool>(changetype<usize>(this) + 110);
     }
 }
 
 @inline export function NewMonsterDataViewer(reader: karmem.Reader, offset: u32): MonsterDataViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return changetype<MonsterDataViewer>(changetype<usize>(_Null))
     }
 
@@ -789,11 +781,11 @@ export class MonsterDataViewer {
 }
 @unmanaged
 export class MonsterViewer {
-    private _0: u64;
+    private _0: u32;
 
     @inline
     SizeOf(): u32 {
-        return 8;
+        return 4;
     }
     @inline
     Data(reader: karmem.Reader): MonsterDataViewer {
@@ -803,7 +795,7 @@ export class MonsterViewer {
 }
 
 @inline export function NewMonsterViewer(reader: karmem.Reader, offset: u32): MonsterViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return changetype<MonsterViewer>(changetype<usize>(_Null))
     }
 
@@ -813,8 +805,7 @@ export class MonsterViewer {
 @unmanaged
 export class MonstersViewer {
     private _0: u64;
-    private _1: u64;
-    private _2: u64;
+    private _1: u32;
 
     @inline
     SizeOf(): u32 {
@@ -822,7 +813,7 @@ export class MonstersViewer {
     }
     @inline
     Monsters(reader: karmem.Reader): karmem.Slice<MonsterViewer> {
-        if ((<u32>4 + <u32>12) > this.SizeOf()) {
+        if ((<u32>4 + <u32>8) > this.SizeOf()) {
             return new karmem.Slice<MonsterViewer>(0,0,0)
         }
         let offset: u32 = load<u32>(changetype<usize>(this) + 4);
@@ -830,16 +821,16 @@ export class MonstersViewer {
         if (!reader.IsValidOffset(offset, size)) {
             return new karmem.Slice<MonsterViewer>(0, 0, 0);
         }
-        let length = size / 8;
+        let length = size / 4;
         if (length > 2000) {
             length = 2000;
         }
-        return new karmem.Slice<MonsterViewer>(reader.Pointer + offset, length, 8);
+        return new karmem.Slice<MonsterViewer>(reader.Pointer + offset, length, 4);
     }
 }
 
 @inline export function NewMonstersViewer(reader: karmem.Reader, offset: u32): MonstersViewer {
-    if (!reader.IsValidOffset(offset, 8)) {
+    if (!reader.IsValidOffset(offset, 4)) {
         return changetype<MonstersViewer>(changetype<usize>(_Null))
     }
 

--- a/benchmark/km/game_generated.zig
+++ b/benchmark/km/game_generated.zig
@@ -5,8 +5,8 @@ const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const mem = @import("std").mem;
 
-var _Null: [152]u8 = [_]u8{ 0 } ** 152;
-var _NullReader: karmem.Reader = karmem.NewReader(std.heap.page_allocator, _Null[0..152]);
+var _Null: [111]u8 = [_]u8{ 0 } ** 111;
+var _NullReader: karmem.Reader = karmem.NewReader(std.heap.page_allocator, _Null[0..111]);
 
 
 pub const EnumColor = enum(u8) {
@@ -55,7 +55,7 @@ pub const Vec3 = struct {
 
     pub fn Write(x: *Vec3, writer: *karmem.Writer, start: usize) Allocator.Error!u32 {
         var offset: u32 = @intCast(u32, start);
-        var size: u32 = 16;
+        var size: u32 = 12;
         if (offset == 0) {
             offset = try karmem.Writer.Alloc(writer, size);
         }
@@ -106,7 +106,7 @@ pub const WeaponData = struct {
 
     pub fn Write(x: *WeaponData, writer: *karmem.Writer, start: usize) Allocator.Error!u32 {
         var offset: u32 = @intCast(u32, start);
-        var size: u32 = 16;
+        var size: u32 = 12;
         if (offset == 0) {
             offset = try karmem.Writer.Alloc(writer, size);
         }
@@ -155,11 +155,11 @@ pub const Weapon = struct {
 
     pub fn Write(x: *Weapon, writer: *karmem.Writer, start: usize) Allocator.Error!u32 {
         var offset: u32 = @intCast(u32, start);
-        var size: u32 = 8;
+        var size: u32 = 4;
         if (offset == 0) {
             offset = try karmem.Writer.Alloc(writer, size);
         }
-        var __DataSize: usize = 16;
+        var __DataSize: usize = 12;
         var __DataOffset = try karmem.Writer.Alloc(writer, __DataSize);
 
         karmem.Writer.WriteAt(writer, offset+0, @ptrCast([*]const u8, &__DataOffset), 4);
@@ -217,73 +217,65 @@ pub const MonsterData = struct {
 
     pub fn Write(x: *MonsterData, writer: *karmem.Writer, start: usize) Allocator.Error!u32 {
         var offset: u32 = @intCast(u32, start);
-        var size: u32 = 152;
+        var size: u32 = 111;
         if (offset == 0) {
             offset = try karmem.Writer.Alloc(writer, size);
         }
-        var sizeData: u32 = 147;
+        var sizeData: u32 = 111;
         karmem.Writer.WriteAt(writer, offset, @ptrCast([*]const u8, &sizeData), 4);
         var __PosOffset = offset + 4;
         _ = try Vec3.Write(&x.Pos, writer, __PosOffset);
-        var __ManaOffset = offset + 20;
+        var __ManaOffset = offset + 16;
         karmem.Writer.WriteAt(writer, __ManaOffset, @ptrCast([*]const u8, &x.Mana), 2);
-        var __HealthOffset = offset + 22;
+        var __HealthOffset = offset + 18;
         karmem.Writer.WriteAt(writer, __HealthOffset, @ptrCast([*]const u8, &x.Health), 2);
         var __NameSize: usize = 1 * x.Name.len;
         var __NameOffset = try karmem.Writer.Alloc(writer, __NameSize);
 
-        karmem.Writer.WriteAt(writer, offset+24, @ptrCast([*]const u8, &__NameOffset), 4);
-        karmem.Writer.WriteAt(writer, offset+24+4, @ptrCast([*]const u8, &__NameSize), 4);
-        var __NameSizeEach: u32 = 1;
-        karmem.Writer.WriteAt(writer, offset+24+4+4, @ptrCast([*]const u8, &__NameSizeEach), 4);
+        karmem.Writer.WriteAt(writer, offset+20, @ptrCast([*]const u8, &__NameOffset), 4);
+        karmem.Writer.WriteAt(writer, offset+20+4, @ptrCast([*]const u8, &__NameSize), 4);
         karmem.Writer.WriteAt(writer, __NameOffset, x.Name.ptr, __NameSize);
-        var __TeamOffset = offset + 36;
+        var __TeamOffset = offset + 28;
         karmem.Writer.WriteAt(writer, __TeamOffset, @ptrCast([*]const u8, &x.Team), 1);
         var __InventorySize: usize = 1 * x.Inventory.len;
         var __InventoryOffset = try karmem.Writer.Alloc(writer, __InventorySize);
 
-        karmem.Writer.WriteAt(writer, offset+37, @ptrCast([*]const u8, &__InventoryOffset), 4);
-        karmem.Writer.WriteAt(writer, offset+37+4, @ptrCast([*]const u8, &__InventorySize), 4);
-        var __InventorySizeEach: u32 = 1;
-        karmem.Writer.WriteAt(writer, offset+37+4+4, @ptrCast([*]const u8, &__InventorySizeEach), 4);
+        karmem.Writer.WriteAt(writer, offset+29, @ptrCast([*]const u8, &__InventoryOffset), 4);
+        karmem.Writer.WriteAt(writer, offset+29+4, @ptrCast([*]const u8, &__InventorySize), 4);
         karmem.Writer.WriteAt(writer, __InventoryOffset, @ptrCast(*[]const u8, &x.Inventory).ptr, __InventorySize);
-        var __ColorOffset = offset + 49;
+        var __ColorOffset = offset + 37;
         karmem.Writer.WriteAt(writer, __ColorOffset, @ptrCast([*]const u8, &x.Color), 1);
         var __HitboxSize: usize = 8 * x.Hitbox.len;
-        var __HitboxOffset = offset + 50;
+        var __HitboxOffset = offset + 38;
         karmem.Writer.WriteAt(writer, __HitboxOffset, @ptrCast([*]const u8, &x.Hitbox), __HitboxSize);
         var __StatusSize: usize = 4 * x.Status.len;
         var __StatusOffset = try karmem.Writer.Alloc(writer, __StatusSize);
 
-        karmem.Writer.WriteAt(writer, offset+90, @ptrCast([*]const u8, &__StatusOffset), 4);
-        karmem.Writer.WriteAt(writer, offset+90+4, @ptrCast([*]const u8, &__StatusSize), 4);
-        var __StatusSizeEach: u32 = 4;
-        karmem.Writer.WriteAt(writer, offset+90+4+4, @ptrCast([*]const u8, &__StatusSizeEach), 4);
+        karmem.Writer.WriteAt(writer, offset+78, @ptrCast([*]const u8, &__StatusOffset), 4);
+        karmem.Writer.WriteAt(writer, offset+78+4, @ptrCast([*]const u8, &__StatusSize), 4);
         karmem.Writer.WriteAt(writer, __StatusOffset, @ptrCast(*[]const u8, &x.Status).ptr, __StatusSize);
-        var __WeaponsSize: usize = 8 * x.Weapons.len;
-        var __WeaponsOffset = offset + 102;
+        var __WeaponsSize: usize = 4 * x.Weapons.len;
+        var __WeaponsOffset = offset + 86;
         var __WeaponsIndex: usize = 0;
         var __WeaponsEnd: usize = __WeaponsOffset + __WeaponsSize;
         while (__WeaponsOffset < __WeaponsEnd) {
             _ = try Weapon.Write(&x.Weapons[__WeaponsIndex], writer, __WeaponsOffset);
-            __WeaponsOffset = __WeaponsOffset + 8;
+            __WeaponsOffset = __WeaponsOffset + 4;
             __WeaponsIndex = __WeaponsIndex + 1;
         }
-        var __PathSize: usize = 16 * x.Path.len;
+        var __PathSize: usize = 12 * x.Path.len;
         var __PathOffset = try karmem.Writer.Alloc(writer, __PathSize);
 
-        karmem.Writer.WriteAt(writer, offset+134, @ptrCast([*]const u8, &__PathOffset), 4);
-        karmem.Writer.WriteAt(writer, offset+134+4, @ptrCast([*]const u8, &__PathSize), 4);
-        var __PathSizeEach: u32 = 16;
-        karmem.Writer.WriteAt(writer, offset+134+4+4, @ptrCast([*]const u8, &__PathSizeEach), 4);
+        karmem.Writer.WriteAt(writer, offset+102, @ptrCast([*]const u8, &__PathOffset), 4);
+        karmem.Writer.WriteAt(writer, offset+102+4, @ptrCast([*]const u8, &__PathSize), 4);
         var __PathIndex: usize = 0;
         var __PathEnd: usize = __PathOffset + __PathSize;
         while (__PathOffset < __PathEnd) {
             _ = try Vec3.Write(&x.Path[__PathIndex], writer, __PathOffset);
-            __PathOffset = __PathOffset + 16;
+            __PathOffset = __PathOffset + 12;
             __PathIndex = __PathIndex + 1;
         }
-        var __IsAliveOffset = offset + 146;
+        var __IsAliveOffset = offset + 110;
         karmem.Writer.WriteAt(writer, __IsAliveOffset, @ptrCast([*]const u8, &x.IsAlive), 1);
 
         return offset;
@@ -448,11 +440,11 @@ pub const Monster = struct {
 
     pub fn Write(x: *Monster, writer: *karmem.Writer, start: usize) Allocator.Error!u32 {
         var offset: u32 = @intCast(u32, start);
-        var size: u32 = 8;
+        var size: u32 = 4;
         if (offset == 0) {
             offset = try karmem.Writer.Alloc(writer, size);
         }
-        var __DataSize: usize = 152;
+        var __DataSize: usize = 111;
         var __DataOffset = try karmem.Writer.Alloc(writer, __DataSize);
 
         karmem.Writer.WriteAt(writer, offset+0, @ptrCast([*]const u8, &__DataOffset), 4);
@@ -496,24 +488,22 @@ pub const Monsters = struct {
 
     pub fn Write(x: *Monsters, writer: *karmem.Writer, start: usize) Allocator.Error!u32 {
         var offset: u32 = @intCast(u32, start);
-        var size: u32 = 24;
+        var size: u32 = 12;
         if (offset == 0) {
             offset = try karmem.Writer.Alloc(writer, size);
         }
-        var sizeData: u32 = 16;
+        var sizeData: u32 = 12;
         karmem.Writer.WriteAt(writer, offset, @ptrCast([*]const u8, &sizeData), 4);
-        var __MonstersSize: usize = 8 * x.Monsters.len;
+        var __MonstersSize: usize = 4 * x.Monsters.len;
         var __MonstersOffset = try karmem.Writer.Alloc(writer, __MonstersSize);
 
         karmem.Writer.WriteAt(writer, offset+4, @ptrCast([*]const u8, &__MonstersOffset), 4);
         karmem.Writer.WriteAt(writer, offset+4+4, @ptrCast([*]const u8, &__MonstersSize), 4);
-        var __MonstersSizeEach: u32 = 8;
-        karmem.Writer.WriteAt(writer, offset+4+4+4, @ptrCast([*]const u8, &__MonstersSizeEach), 4);
         var __MonstersIndex: usize = 0;
         var __MonstersEnd: usize = __MonstersOffset + __MonstersSize;
         while (__MonstersOffset < __MonstersEnd) {
             _ = try Monster.Write(&x.Monsters[__MonstersIndex], writer, __MonstersOffset);
-            __MonstersOffset = __MonstersOffset + 8;
+            __MonstersOffset = __MonstersOffset + 4;
             __MonstersIndex = __MonstersIndex + 1;
         }
 
@@ -561,12 +551,12 @@ pub fn NewMonsters() Monsters {
 }
 
 
-pub const Vec3Viewer = struct {
-    _data: [16]u8,
+pub const Vec3Viewer = extern struct {
+    _data: [12]u8,
 
     pub fn Size(x: *const Vec3Viewer) u32 {
     _ = x;
-        return 16;
+        return 12;
     }
     pub fn X(x: *const Vec3Viewer) f32 {
         return @ptrCast(*align(1) const f32, x._data[0..0+@sizeOf(f32)]).*;
@@ -581,15 +571,15 @@ pub const Vec3Viewer = struct {
 };
 
 pub fn NewVec3Viewer(reader: *karmem.Reader, offset: u32) *const Vec3Viewer {
-    if (!karmem.Reader.IsValidOffset(reader, offset, 16)) {
+    if (!karmem.Reader.IsValidOffset(reader, offset, 12)) {
         return @ptrCast(*Vec3Viewer, &_Null[0]);
     }
-    var v = @ptrCast(*align(1) const Vec3Viewer, reader.memory[offset..offset+16]);
+    var v = @ptrCast(*align(1) const Vec3Viewer, reader.memory[offset..offset+12]);
     return v;
 }
 
-pub const WeaponDataViewer = struct {
-    _data: [16]u8,
+pub const WeaponDataViewer = extern struct {
+    _data: [12]u8,
 
     pub fn Size(x: *const WeaponDataViewer) u32 {
     _ = x;
@@ -611,22 +601,22 @@ pub const WeaponDataViewer = struct {
 };
 
 pub fn NewWeaponDataViewer(reader: *karmem.Reader, offset: u32) *const WeaponDataViewer {
-    if (!karmem.Reader.IsValidOffset(reader, offset, 8)) {
+    if (!karmem.Reader.IsValidOffset(reader, offset, 4)) {
         return @ptrCast(*WeaponDataViewer, &_Null[0]);
     }
-    var v = @ptrCast(*align(1) const WeaponDataViewer, reader.memory[offset..offset+8]);
+    var v = @ptrCast(*align(1) const WeaponDataViewer, reader.memory[offset..offset+4]);
     if (!karmem.Reader.IsValidOffset(reader, offset, WeaponDataViewer.Size(v))) {
         return @ptrCast(*WeaponDataViewer, &_Null[0]);
     }
     return v;
 }
 
-pub const WeaponViewer = struct {
-    _data: [8]u8,
+pub const WeaponViewer = extern struct {
+    _data: [4]u8,
 
     pub fn Size(x: *const WeaponViewer) u32 {
     _ = x;
-        return 8;
+        return 4;
     }
     pub fn Data(x: *const WeaponViewer, reader: *karmem.Reader) *const WeaponDataViewer {
         var offset = @ptrCast(*align(1) const u32, x._data[0..0+4]).*;
@@ -636,44 +626,44 @@ pub const WeaponViewer = struct {
 };
 
 pub fn NewWeaponViewer(reader: *karmem.Reader, offset: u32) *const WeaponViewer {
-    if (!karmem.Reader.IsValidOffset(reader, offset, 8)) {
+    if (!karmem.Reader.IsValidOffset(reader, offset, 4)) {
         return @ptrCast(*WeaponViewer, &_Null[0]);
     }
-    var v = @ptrCast(*align(1) const WeaponViewer, reader.memory[offset..offset+8]);
+    var v = @ptrCast(*align(1) const WeaponViewer, reader.memory[offset..offset+4]);
     return v;
 }
 
-pub const MonsterDataViewer = struct {
-    _data: [152]u8,
+pub const MonsterDataViewer = extern struct {
+    _data: [111]u8,
 
     pub fn Size(x: *const MonsterDataViewer) u32 {
     _ = x;
         return @ptrCast(*align(1) const u32, x._data[0..4]).*;
     }
     pub fn Pos(x: *const MonsterDataViewer) *const Vec3Viewer {
-        if ((4 + 16) > MonsterDataViewer.Size(x)) {
+        if ((4 + 12) > MonsterDataViewer.Size(x)) {
             return @ptrCast(*Vec3Viewer, &_Null[0]);
         }
         return @ptrCast(*const Vec3Viewer, x._data[4..4+@sizeOf(*const Vec3Viewer)]);
     }
     pub fn Mana(x: *const MonsterDataViewer) i16 {
-        if ((20 + 2) > MonsterDataViewer.Size(x)) {
+        if ((16 + 2) > MonsterDataViewer.Size(x)) {
             return 0;
         }
-        return @ptrCast(*align(1) const i16, x._data[20..20+@sizeOf(i16)]).*;
+        return @ptrCast(*align(1) const i16, x._data[16..16+@sizeOf(i16)]).*;
     }
     pub fn Health(x: *const MonsterDataViewer) i16 {
-        if ((22 + 2) > MonsterDataViewer.Size(x)) {
+        if ((18 + 2) > MonsterDataViewer.Size(x)) {
             return 0;
         }
-        return @ptrCast(*align(1) const i16, x._data[22..22+@sizeOf(i16)]).*;
+        return @ptrCast(*align(1) const i16, x._data[18..18+@sizeOf(i16)]).*;
     }
     pub fn Name(x: *const MonsterDataViewer, reader: *karmem.Reader) []u8 {
-        if ((24 + 12) > MonsterDataViewer.Size(x)) {
+        if ((20 + 8) > MonsterDataViewer.Size(x)) {
             return &[_]u8{};
         }
-        var offset = @ptrCast(*align(1) const u32, x._data[24..24+4]).*;
-        var size = @ptrCast(*align(1) const u32, x._data[24+4..24+4+4]).*;
+        var offset = @ptrCast(*align(1) const u32, x._data[20..20+4]).*;
+        var size = @ptrCast(*align(1) const u32, x._data[20+4..20+4+4]).*;
         if (!karmem.Reader.IsValidOffset(reader, offset, size)) {
             return&[_]u8{};
         }
@@ -685,17 +675,17 @@ pub const MonsterDataViewer = struct {
         return @ptrCast(*[]u8, &slice).*;
     }
     pub fn Team(x: *const MonsterDataViewer) EnumTeam {
-        if ((36 + 1) > MonsterDataViewer.Size(x)) {
+        if ((28 + 1) > MonsterDataViewer.Size(x)) {
             return DefaultEnumTeam;
         }
-        return @ptrCast(*align(1) const EnumTeam, x._data[36..36+@sizeOf(EnumTeam)]).*;
+        return @ptrCast(*align(1) const EnumTeam, x._data[28..28+@sizeOf(EnumTeam)]).*;
     }
     pub fn Inventory(x: *const MonsterDataViewer, reader: *karmem.Reader) []u8 {
-        if ((37 + 12) > MonsterDataViewer.Size(x)) {
+        if ((29 + 8) > MonsterDataViewer.Size(x)) {
             return &[_]u8{};
         }
-        var offset = @ptrCast(*align(1) const u32, x._data[37..37+4]).*;
-        var size = @ptrCast(*align(1) const u32, x._data[37+4..37+4+4]).*;
+        var offset = @ptrCast(*align(1) const u32, x._data[29..29+4]).*;
+        var size = @ptrCast(*align(1) const u32, x._data[29+4..29+4+4]).*;
         if (!karmem.Reader.IsValidOffset(reader, offset, size)) {
             return&[_]u8{};
         }
@@ -707,24 +697,24 @@ pub const MonsterDataViewer = struct {
         return @ptrCast(*[]u8, &slice).*;
     }
     pub fn Color(x: *const MonsterDataViewer) EnumColor {
-        if ((49 + 1) > MonsterDataViewer.Size(x)) {
+        if ((37 + 1) > MonsterDataViewer.Size(x)) {
             return DefaultEnumColor;
         }
-        return @ptrCast(*align(1) const EnumColor, x._data[49..49+@sizeOf(EnumColor)]).*;
+        return @ptrCast(*align(1) const EnumColor, x._data[37..37+@sizeOf(EnumColor)]).*;
     }
     pub fn Hitbox(x: *const MonsterDataViewer) []f64 {
-        if ((50 + 40) > MonsterDataViewer.Size(x)) {
+        if ((38 + 40) > MonsterDataViewer.Size(x)) {
             return &[_]f64{};
         }
-        var slice = [2]usize{@ptrToInt(x)+50, 5};
+        var slice = [2]usize{@ptrToInt(x)+38, 5};
         return @ptrCast(*align(1) const []f64, &slice).*;
     }
     pub fn Status(x: *const MonsterDataViewer, reader: *karmem.Reader) []i32 {
-        if ((90 + 12) > MonsterDataViewer.Size(x)) {
+        if ((78 + 8) > MonsterDataViewer.Size(x)) {
             return &[_]i32{};
         }
-        var offset = @ptrCast(*align(1) const u32, x._data[90..90+4]).*;
-        var size = @ptrCast(*align(1) const u32, x._data[90+4..90+4+4]).*;
+        var offset = @ptrCast(*align(1) const u32, x._data[78..78+4]).*;
+        var size = @ptrCast(*align(1) const u32, x._data[78+4..78+4+4]).*;
         if (!karmem.Reader.IsValidOffset(reader, offset, size)) {
             return&[_]i32{};
         }
@@ -736,22 +726,22 @@ pub const MonsterDataViewer = struct {
         return @ptrCast(*[]i32, &slice).*;
     }
     pub fn Weapons(x: *const MonsterDataViewer) []const WeaponViewer {
-        if ((102 + 32) > MonsterDataViewer.Size(x)) {
+        if ((86 + 16) > MonsterDataViewer.Size(x)) {
             return &[_]WeaponViewer{};
         }
-        var slice = [2]usize{@ptrToInt(x)+102, 4};
+        var slice = [2]usize{@ptrToInt(x)+86, 4};
         return @ptrCast(*align(1) const []WeaponViewer, &slice).*;
     }
     pub fn Path(x: *const MonsterDataViewer, reader: *karmem.Reader) []const Vec3Viewer {
-        if ((134 + 12) > MonsterDataViewer.Size(x)) {
+        if ((102 + 8) > MonsterDataViewer.Size(x)) {
             return &[_]Vec3Viewer{};
         }
-        var offset = @ptrCast(*align(1) const u32, x._data[134..134+4]).*;
-        var size = @ptrCast(*align(1) const u32, x._data[134+4..134+4+4]).*;
+        var offset = @ptrCast(*align(1) const u32, x._data[102..102+4]).*;
+        var size = @ptrCast(*align(1) const u32, x._data[102+4..102+4+4]).*;
         if (!karmem.Reader.IsValidOffset(reader, offset, size)) {
             return &[_]Vec3Viewer{};
         }
-        var length = size / 16;
+        var length = size / 12;
         if (length > 2000) {
             length = 2000;
         }
@@ -759,31 +749,31 @@ pub const MonsterDataViewer = struct {
         return @ptrCast(*[]const Vec3Viewer, &slice).*;
     }
     pub fn IsAlive(x: *const MonsterDataViewer) bool {
-        if ((146 + 1) > MonsterDataViewer.Size(x)) {
+        if ((110 + 1) > MonsterDataViewer.Size(x)) {
             return false;
         }
-        return @ptrCast(*align(1) const bool, x._data[146..146+@sizeOf(bool)]).*;
+        return @ptrCast(*align(1) const bool, x._data[110..110+@sizeOf(bool)]).*;
     }
 
 };
 
 pub fn NewMonsterDataViewer(reader: *karmem.Reader, offset: u32) *const MonsterDataViewer {
-    if (!karmem.Reader.IsValidOffset(reader, offset, 8)) {
+    if (!karmem.Reader.IsValidOffset(reader, offset, 4)) {
         return @ptrCast(*MonsterDataViewer, &_Null[0]);
     }
-    var v = @ptrCast(*align(1) const MonsterDataViewer, reader.memory[offset..offset+8]);
+    var v = @ptrCast(*align(1) const MonsterDataViewer, reader.memory[offset..offset+4]);
     if (!karmem.Reader.IsValidOffset(reader, offset, MonsterDataViewer.Size(v))) {
         return @ptrCast(*MonsterDataViewer, &_Null[0]);
     }
     return v;
 }
 
-pub const MonsterViewer = struct {
-    _data: [8]u8,
+pub const MonsterViewer = extern struct {
+    _data: [4]u8,
 
     pub fn Size(x: *const MonsterViewer) u32 {
     _ = x;
-        return 8;
+        return 4;
     }
     pub fn Data(x: *const MonsterViewer, reader: *karmem.Reader) *const MonsterDataViewer {
         var offset = @ptrCast(*align(1) const u32, x._data[0..0+4]).*;
@@ -793,22 +783,22 @@ pub const MonsterViewer = struct {
 };
 
 pub fn NewMonsterViewer(reader: *karmem.Reader, offset: u32) *const MonsterViewer {
-    if (!karmem.Reader.IsValidOffset(reader, offset, 8)) {
+    if (!karmem.Reader.IsValidOffset(reader, offset, 4)) {
         return @ptrCast(*MonsterViewer, &_Null[0]);
     }
-    var v = @ptrCast(*align(1) const MonsterViewer, reader.memory[offset..offset+8]);
+    var v = @ptrCast(*align(1) const MonsterViewer, reader.memory[offset..offset+4]);
     return v;
 }
 
-pub const MonstersViewer = struct {
-    _data: [24]u8,
+pub const MonstersViewer = extern struct {
+    _data: [12]u8,
 
     pub fn Size(x: *const MonstersViewer) u32 {
     _ = x;
         return @ptrCast(*align(1) const u32, x._data[0..4]).*;
     }
     pub fn Monsters(x: *const MonstersViewer, reader: *karmem.Reader) []const MonsterViewer {
-        if ((4 + 12) > MonstersViewer.Size(x)) {
+        if ((4 + 8) > MonstersViewer.Size(x)) {
             return &[_]MonsterViewer{};
         }
         var offset = @ptrCast(*align(1) const u32, x._data[4..4+4]).*;
@@ -816,7 +806,7 @@ pub const MonstersViewer = struct {
         if (!karmem.Reader.IsValidOffset(reader, offset, size)) {
             return &[_]MonsterViewer{};
         }
-        var length = size / 8;
+        var length = size / 4;
         if (length > 2000) {
             length = 2000;
         }
@@ -827,10 +817,10 @@ pub const MonstersViewer = struct {
 };
 
 pub fn NewMonstersViewer(reader: *karmem.Reader, offset: u32) *const MonstersViewer {
-    if (!karmem.Reader.IsValidOffset(reader, offset, 8)) {
+    if (!karmem.Reader.IsValidOffset(reader, offset, 4)) {
         return @ptrCast(*MonstersViewer, &_Null[0]);
     }
-    var v = @ptrCast(*align(1) const MonstersViewer, reader.memory[offset..offset+8]);
+    var v = @ptrCast(*align(1) const MonstersViewer, reader.memory[offset..offset+4]);
     if (!karmem.Reader.IsValidOffset(reader, offset, MonstersViewer.Size(v))) {
         return @ptrCast(*MonstersViewer, &_Null[0]);
     }

--- a/benchmark/km/game_generated.zig
+++ b/benchmark/km/game_generated.zig
@@ -90,6 +90,9 @@ pub fn NewVec3() Vec3 {
 }
 pub const WeaponData = struct {
     Damage: i32 = 0,
+    Ammo: u16 = 0,
+    ClipSize: u8 = 0,
+    ReloadTime: f32 = 0,
     Range: i32 = 0,
 
     pub fn PacketIdentifier() EnumPacketIdentifier {
@@ -106,15 +109,21 @@ pub const WeaponData = struct {
 
     pub fn Write(x: *WeaponData, writer: *karmem.Writer, start: usize) Allocator.Error!u32 {
         var offset: u32 = @intCast(u32, start);
-        var size: u32 = 12;
+        var size: u32 = 19;
         if (offset == 0) {
             offset = try karmem.Writer.Alloc(writer, size);
         }
-        var sizeData: u32 = 12;
+        var sizeData: u32 = 19;
         karmem.Writer.WriteAt(writer, offset, @ptrCast([*]const u8, &sizeData), 4);
         var __DamageOffset = offset + 4;
         karmem.Writer.WriteAt(writer, __DamageOffset, @ptrCast([*]const u8, &x.Damage), 4);
-        var __RangeOffset = offset + 8;
+        var __AmmoOffset = offset + 8;
+        karmem.Writer.WriteAt(writer, __AmmoOffset, @ptrCast([*]const u8, &x.Ammo), 2);
+        var __ClipSizeOffset = offset + 10;
+        karmem.Writer.WriteAt(writer, __ClipSizeOffset, @ptrCast([*]const u8, &x.ClipSize), 1);
+        var __ReloadTimeOffset = offset + 11;
+        karmem.Writer.WriteAt(writer, __ReloadTimeOffset, @ptrCast([*]const u8, &x.ReloadTime), 4);
+        var __RangeOffset = offset + 15;
         karmem.Writer.WriteAt(writer, __RangeOffset, @ptrCast([*]const u8, &x.Range), 4);
 
         return offset;
@@ -128,6 +137,9 @@ pub const WeaponData = struct {
         _ = x;
         _ = reader;
         x.Damage = WeaponDataViewer.Damage(viewer);
+        x.Ammo = WeaponDataViewer.Ammo(viewer);
+        x.ClipSize = WeaponDataViewer.ClipSize(viewer);
+        x.ReloadTime = WeaponDataViewer.ReloadTime(viewer);
         x.Range = WeaponDataViewer.Range(viewer);
     }
 
@@ -159,7 +171,7 @@ pub const Weapon = struct {
         if (offset == 0) {
             offset = try karmem.Writer.Alloc(writer, size);
         }
-        var __DataSize: usize = 12;
+        var __DataSize: usize = 19;
         var __DataOffset = try karmem.Writer.Alloc(writer, __DataSize);
 
         karmem.Writer.WriteAt(writer, offset+0, @ptrCast([*]const u8, &__DataOffset), 4);
@@ -579,7 +591,7 @@ pub fn NewVec3Viewer(reader: *karmem.Reader, offset: u32) *const Vec3Viewer {
 }
 
 pub const WeaponDataViewer = extern struct {
-    _data: [12]u8,
+    _data: [19]u8,
 
     pub fn Size(x: *const WeaponDataViewer) u32 {
     _ = x;
@@ -591,11 +603,29 @@ pub const WeaponDataViewer = extern struct {
         }
         return @ptrCast(*align(1) const i32, x._data[4..4+@sizeOf(i32)]).*;
     }
-    pub fn Range(x: *const WeaponDataViewer) i32 {
-        if ((8 + 4) > WeaponDataViewer.Size(x)) {
+    pub fn Ammo(x: *const WeaponDataViewer) u16 {
+        if ((8 + 2) > WeaponDataViewer.Size(x)) {
             return 0;
         }
-        return @ptrCast(*align(1) const i32, x._data[8..8+@sizeOf(i32)]).*;
+        return @ptrCast(*align(1) const u16, x._data[8..8+@sizeOf(u16)]).*;
+    }
+    pub fn ClipSize(x: *const WeaponDataViewer) u8 {
+        if ((10 + 1) > WeaponDataViewer.Size(x)) {
+            return 0;
+        }
+        return @ptrCast(*align(1) const u8, x._data[10..10+@sizeOf(u8)]).*;
+    }
+    pub fn ReloadTime(x: *const WeaponDataViewer) f32 {
+        if ((11 + 4) > WeaponDataViewer.Size(x)) {
+            return 0;
+        }
+        return @ptrCast(*align(1) const f32, x._data[11..11+@sizeOf(f32)]).*;
+    }
+    pub fn Range(x: *const WeaponDataViewer) i32 {
+        if ((15 + 4) > WeaponDataViewer.Size(x)) {
+            return 0;
+        }
+        return @ptrCast(*align(1) const i32, x._data[15..15+@sizeOf(i32)]).*;
     }
 
 };

--- a/benchmark/main.odin
+++ b/benchmark/main.odin
@@ -73,17 +73,74 @@ KBenchmarkDecodeSumVec3 :: proc "c" (size: u32) -> f32 #no_bounds_check {
     monsters := km.NewMonstersViewer(&KarmemReader, 0)
     monsterList := km.MonstersViewerMonsters(monsters, &KarmemReader)
 
-    sum := km.NewVec3();
+    sum := f32(0)
     for i := 0; i < len(monsterList); i += 1 {
         path := km.MonsterDataViewerPath(km.MonsterViewerData(&monsterList[i], &KarmemReader), &KarmemReader)
 
         for p := 0; p < len(path); p += 1 {
             pp := &path[p]
-            sum.X += km.Vec3ViewerX(pp)
-            sum.Y += km.Vec3ViewerY(pp)
-            sum.Z += km.Vec3ViewerZ(pp)
+            sum += km.Vec3ViewerX(pp) + km.Vec3ViewerY(pp) + km.Vec3ViewerZ(pp)
         }
     }
 
-    return sum.X+sum.Y+sum.Z
+    return sum
+}
+
+@export
+KBenchmarkDecodeSumUint8 :: proc "c" (size: u32) -> u32 #no_bounds_check {
+    context = runtime.default_context()
+    context.allocator = HeapAllocator
+
+    karmem.ReaderSetSize(&KarmemReader, size)
+
+    monsters := km.NewMonstersViewer(&KarmemReader, 0)
+    monsterList := km.MonstersViewerMonsters(monsters, &KarmemReader)
+
+    sum := u32(0)
+    for i := 0; i < len(monsterList); i += 1 {
+        inv := km.MonsterDataViewerInventory(km.MonsterViewerData(&monsterList[i], &KarmemReader), &KarmemReader)
+
+        for j := 0; j < len(inv); j += 1 {
+            sum += u32(inv[j])
+        }
+    }
+
+    return sum
+}
+
+@export
+KBenchmarkDecodeSumStats :: proc "c" (size: u32) -> u32 #no_bounds_check {
+    context = runtime.default_context()
+    context.allocator = HeapAllocator
+
+    karmem.ReaderSetSize(&KarmemReader, size)
+
+    monsters := km.NewMonstersViewer(&KarmemReader, 0)
+    monsterList := km.MonstersViewerMonsters(monsters, &KarmemReader)
+
+    sum := km.NewWeaponData()
+    for i := 0; i < len(monsterList); i += 1 {
+        weapons := km.MonsterDataViewerWeapons(km.MonsterViewerData(&monsterList[i], &KarmemReader))
+
+        for j := 0; j < len(weapons); j += 1 {
+			data := km.WeaponViewerData(&weapons[j], &KarmemReader)
+			sum.Ammo += km.WeaponDataViewerAmmo(data)
+			sum.Damage += km.WeaponDataViewerDamage(data)
+			sum.ClipSize += km.WeaponDataViewerClipSize(data)
+			sum.ReloadTime += km.WeaponDataViewerReloadTime(data)
+			sum.Range += km.WeaponDataViewerRange(data)
+        }
+    }
+
+    karmem.WriterReset(&KarmemWriter)
+    km.WeaponDataWriteAsRoot(&sum, &KarmemWriter)
+    return u32(len(karmem.WriterBytes(&KarmemWriter)))
+}
+
+@export
+KNOOP :: proc "c" () -> u32 #no_bounds_check {
+    context = runtime.default_context()
+    context.allocator = HeapAllocator
+
+    return 42
 }

--- a/benchmark/main.ts
+++ b/benchmark/main.ts
@@ -1,5 +1,6 @@
 import * as karmem from "../assemblyscript/karmem"
 import * as km from "./km/game_generated"
+import {Writer} from "../assemblyscript/karmem";
 
 let InputMemory = new StaticArray<u8>(8_000_000);
 let OutputMemory = new Array<u8>(8_000_000);
@@ -22,28 +23,74 @@ export function KBenchmarkEncodeObjectAPI() :void {
 }
 
 export function KBenchmarkDecodeObjectAPI(size: u32) : void {
-  KarmemReader.SetSize(size)
+  KarmemReader.SetSize(size);
   km.Monsters.ReadAsRoot(KarmemStruct, KarmemReader);
 }
 
 export function KBenchmarkDecodeSumVec3(size: u32) : f32 {
-  KarmemReader.SetSize(size)
+  KarmemReader.SetSize(size);
 
   let monsters = km.NewMonstersViewer(KarmemReader, 0);
   let monsterList = monsters.Monsters(KarmemReader);
 
-  let sum : km.Vec3 = km.NewVec3();
+  let sum : f32 = 0;
   for (let i = 0; i < monsterList.length; i++) {
-    let data = monsterList[i].Data(KarmemReader)
+    let data = monsterList[i].Data(KarmemReader);
     let path = data.Path(KarmemReader);
 
     for (let p = 0; p < path.length; p++) {
-      let pp = path[p]
-      sum.X += pp.X();
-      sum.Y += pp.Y();
-      sum.Z += pp.Z();
+      let pp = path[p];
+      sum += pp.X() + pp.Y() + pp.Z();
     }
   }
 
-  return sum.X + sum.Y + sum.Z;
+  return sum;
+}
+
+export function KBenchmarkDecodeSumUint8(size: u32) : u32 {
+  KarmemReader.SetSize(size);
+
+  let monsters = km.NewMonstersViewer(KarmemReader, 0);
+  let monstersList = monsters.Monsters(KarmemReader);
+
+  let sum: u32 = 0
+  for (let i = 0; i < monstersList.length; i++) {
+    let inv = monstersList[i].Data(KarmemReader).Inventory(KarmemReader);
+
+    for (let j = 0; j < inv.length; j++) {
+      sum += u32(inv[j]);
+    }
+  }
+
+  return sum;
+}
+
+//export KBenchmarkDecodeSumStats
+export function KBenchmarkDecodeSumStats(size: u32) : u32 {
+  KarmemReader.SetSize(size)
+
+  let monsters = km.NewMonstersViewer(KarmemReader, 0)
+  let monstersList = monsters.Monsters(KarmemReader)
+
+  let sum: km.WeaponData = km.NewWeaponData()
+  for (let i = 0; i < monstersList.length; i++) {
+    let weapons = monstersList[i].Data(KarmemReader).Weapons()
+
+    for (let j = 0; j < weapons.length; j++) {
+      let data = weapons[j].Data(KarmemReader)
+      sum.Ammo += data.Ammo()
+      sum.Damage += data.Damage()
+      sum.ClipSize += data.ClipSize()
+      sum.ReloadTime += data.ReloadTime()
+      sum.Range += data.Range()
+    }
+  }
+
+  KarmemWriter.Reset()
+  km.WeaponData.WriteAsRoot(sum, KarmemWriter);
+  return KarmemWriter.Bytes().length
+}
+
+export function KNOOP() : u32 {
+  return 42;
 }

--- a/benchmark/main_bridge.go
+++ b/benchmark/main_bridge.go
@@ -21,6 +21,12 @@ func (f Functions) String() string {
 		return "KBenchmarkDecodeObjectAPI"
 	case FunctionKBenchmarkDecodeSumVec3:
 		return "KBenchmarkDecodeSumVec3"
+	case FunctionKBenchmarkDecodeSumUint8:
+		return "KBenchmarkDecodeSumUint8"
+	case FunctionKBenchmarkDecodeSumStats:
+		return "KBenchmarkDecodeSumStats"
+	case FunctionKNOOP:
+		return "KNOOP"
 	default:
 		panic("invalid function")
 	}
@@ -30,4 +36,7 @@ const (
 	FunctionKBenchmarkDecodeObjectAPI Functions = 1 + iota
 	FunctionKBenchmarkEncodeObjectAPI
 	FunctionKBenchmarkDecodeSumVec3
+	FunctionKBenchmarkDecodeSumUint8
+	FunctionKBenchmarkDecodeSumStats
+	FunctionKNOOP
 )

--- a/benchmark/main_fbs.go
+++ b/benchmark/main_fbs.go
@@ -14,7 +14,7 @@ var (
 )
 
 func init() {
-    _Writer = &flatbuffers.Builder{Bytes: OutputMemory[:]}
+	_Writer = &flatbuffers.Builder{Bytes: OutputMemory[:]}
 }
 
 //export KBenchmarkEncodeObjectAPI
@@ -34,7 +34,7 @@ func KBenchmarkDecodeSumVec3(_ uint32) float32 {
 
 	var monster fbs.Monster
 	var path fbs.Vec3
-	var sum fbs.Vec3T
+	var sum float32
 
 	l := _Reader.MonstersLength()
 	for i := 0; i < l; i++ {
@@ -43,10 +43,8 @@ func KBenchmarkDecodeSumVec3(_ uint32) float32 {
 		l := monster.PathLength()
 		for p := 0; p < l; p++ {
 			monster.Path(&path, p)
-			sum.X += path.X()
-			sum.Y += path.Y()
-			sum.Z += path.Z()
+			sum += path.X() + path.Y() + path.Z()
 		}
 	}
-	return sum.X + sum.Y + sum.Z
+	return sum
 }

--- a/benchmark/main_km.go
+++ b/benchmark/main_km.go
@@ -40,16 +40,66 @@ func KBenchmarkDecodeSumVec3(size uint32) float32 {
 	monsters := km.NewMonstersViewer(_Reader, 0)
 	monstersList := monsters.Monsters(_Reader)
 
-	var sum km.Vec3
+	var sum float32
 	for i := range monstersList {
 		path := monstersList[i].Data(_Reader).Path(_Reader)
 
 		for p := range path {
-			sum.X += path[p].X()
-			sum.Y += path[p].Y()
-			sum.Z += path[p].Z()
+			pp := &path[p]
+			sum += pp.X() + pp.Y() + pp.Z()
+		}
+	}
+	return sum
+}
+
+//export KBenchmarkDecodeSumUint8
+func KBenchmarkDecodeSumUint8(size uint32) uint32 {
+	_Reader.SetSize(size)
+
+	monsters := km.NewMonstersViewer(_Reader, 0)
+	monstersList := monsters.Monsters(_Reader)
+
+	var sum uint32
+	for i := range monstersList {
+		inv := monstersList[i].Data(_Reader).Inventory(_Reader)
+
+		for j := range inv {
+			sum += uint32(inv[j])
 		}
 	}
 
-	return sum.X + sum.Y + sum.Z
+	return sum
+}
+
+//export KBenchmarkDecodeSumStats
+func KBenchmarkDecodeSumStats(size uint32) uint32 {
+	_Reader.SetSize(size)
+
+	monsters := km.NewMonstersViewer(_Reader, 0)
+	monstersList := monsters.Monsters(_Reader)
+
+	var sum km.WeaponData
+	for i := range monstersList {
+		weapons := monstersList[i].Data(_Reader).Weapons()
+
+		for j := range weapons {
+			data := weapons[j].Data(_Reader)
+			sum.Ammo += data.Ammo()
+			sum.Damage += data.Damage()
+			sum.ClipSize += data.ClipSize()
+			sum.ReloadTime += data.ReloadTime()
+			sum.Range += data.Range()
+		}
+	}
+
+	_Writer.Reset()
+	if _, err := sum.WriteAsRoot(_Writer); err != nil {
+		panic(err)
+	}
+	return uint32(len(_Writer.Bytes()))
+}
+
+//export KNOOP
+func KNOOP() uint32 {
+	return 42
 }

--- a/benchmark/main_km_test.go
+++ b/benchmark/main_km_test.go
@@ -1,0 +1,55 @@
+//go:build !wasi && !struct && !tcp && km && !nobench
+
+package main
+
+import (
+	"testing"
+
+	"benchmark.karmem.org/km"
+	karmem "karmem.org/golang"
+)
+
+func BenchmarkDecodeSumUint8(b *testing.B) {
+	encoded := encode()
+	copy(InputMemory[:], encoded)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	l := uint32(len(encoded))
+	for i := 0; i < b.N; i++ {
+		if n := KBenchmarkDecodeSumUint8(l); n != KSumInventoryExpected {
+			b.Error("invalid sum", n, KSumExpected)
+		}
+	}
+}
+
+func BenchmarkDecodeSumStats(b *testing.B) {
+	encoded := encode()
+	copy(InputMemory[:], encoded)
+
+	reader := karmem.NewReader(OutputMemory[:])
+	b.ReportAllocs()
+	b.ResetTimer()
+	l := uint32(len(encoded))
+	for i := 0; i < b.N; i++ {
+		size := KBenchmarkDecodeSumStats(l)
+		reader.SetSize(size)
+
+		result := km.NewWeaponDataViewer(reader, 0)
+		if n := result.Damage(); n != KSumWeaponStatus.Damage {
+			b.Error("invalid sum", n, KSumWeaponStatus.Damage)
+		}
+
+		if n := result.Range(); n != KSumWeaponStatus.Range {
+			b.Error("invalid sum", n, KSumWeaponStatus.Range)
+		}
+
+		if n := result.Ammo(); n != KSumWeaponStatus.Ammo {
+			b.Error("invalid sum", n, KSumWeaponStatus.Ammo)
+		}
+
+		if n := result.ClipSize(); n != KSumWeaponStatus.ClipSize {
+			b.Error("invalid sum", n, KSumWeaponStatus.ClipSize)
+		}
+	}
+}

--- a/benchmark/main_native_fbs.go
+++ b/benchmark/main_native_fbs.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"math/rand"
+
 	"benchmark.karmem.org/fbs"
 	flatbuffers "github.com/google/flatbuffers/go"
 )
@@ -27,7 +29,6 @@ func initEncode() {
 	KStruct = &fbs.MonstersT{
 		Monsters: make([]*fbs.MonsterT, 1000),
 	}
-	var sum fbs.Vec3T
 	for i := range KStruct.Monsters {
 		KStruct.Monsters[i] = &fbs.MonsterT{
 			Pos:       &fbs.Vec3T{X: 1, Y: 2, Z: 3},
@@ -54,17 +55,14 @@ func initEncode() {
 		}
 		for j := range KStruct.Monsters[i].Path {
 			v := &fbs.Vec3T{
-				X: float32(1),
+				X: float32(1) * rand.Float32(),
 				Y: float32(i),
-				Z: float32(1),
+				Z: float32(i*j) * 0.33,
 			}
-			sum.X += v.X
-			sum.Y += v.Y
-			sum.Z += v.Z
+			KSumExpected += v.X + v.Y + v.Z
 			KStruct.Monsters[i].Path[j] = v
 		}
 	}
-	KSumExpected += sum.X + sum.Y + sum.Z
 }
 
 func encode() []byte {

--- a/benchmark/main_native_km.go
+++ b/benchmark/main_native_km.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"math/rand"
+
 	"benchmark.karmem.org/km"
 	karmem "karmem.org/golang"
 )
@@ -12,6 +14,8 @@ var KStruct km.Monsters
 var KBuilder = karmem.NewWriter(1000)
 var KStarted = false
 var KSumExpected = float32(0.0)
+var KSumInventoryExpected = uint32(0)
+var KSumWeaponStatus = km.WeaponData{}
 
 func init() {
 	initEncode()
@@ -27,7 +31,6 @@ func initEncode() {
 	KStruct = km.Monsters{
 		Monsters: make([]km.Monster, 1000),
 	}
-	var sum km.Vec3
 	for i := range KStruct.Monsters {
 		KStruct.Monsters[i] = km.Monster{
 			Data: km.MonsterData{
@@ -60,17 +63,33 @@ func initEncode() {
 		}
 		for j := range KStruct.Monsters[i].Data.Path {
 			v := km.Vec3{
-				X: float32(1),
+				X: float32(1) * rand.Float32(),
 				Y: float32(i),
-				Z: float32(1),
+				Z: float32(i*j) * 0.33,
 			}
-			sum.X += v.X
-			sum.Y += v.Y
-			sum.Z += v.Z
+			KSumExpected += v.X + v.Y + v.Z
 			KStruct.Monsters[i].Data.Path[j] = v
+
+		}
+		for j := range KStruct.Monsters[i].Data.Inventory {
+			KStruct.Monsters[i].Data.Inventory[j] = byte(i)
+			KSumInventoryExpected += uint32(byte(i))
+		}
+		for j := range KStruct.Monsters[i].Data.Weapons {
+			KStruct.Monsters[i].Data.Weapons[j].Data = km.WeaponData{
+				Damage:     100 + int32(i),
+				Ammo:       uint16(j),
+				ClipSize:   uint8(i),
+				ReloadTime: 1.4232242,
+				Range:      int32(i),
+			}
+			KSumWeaponStatus.Damage += KStruct.Monsters[i].Data.Weapons[j].Data.Damage
+			KSumWeaponStatus.Ammo += KStruct.Monsters[i].Data.Weapons[j].Data.Ammo
+			KSumWeaponStatus.ClipSize += KStruct.Monsters[i].Data.Weapons[j].Data.ClipSize
+			KSumWeaponStatus.ReloadTime += KStruct.Monsters[i].Data.Weapons[j].Data.ReloadTime
+			KSumWeaponStatus.Range += KStruct.Monsters[i].Data.Weapons[j].Data.Range
 		}
 	}
-	KSumExpected += sum.X + sum.Y + sum.Z
 }
 
 func encode() []byte {

--- a/benchmark/main_struct.go
+++ b/benchmark/main_struct.go
@@ -26,16 +26,14 @@ func KBenchmarkDecodeObjectAPI() {
 
 //export KBenchmarkDecodeSumVec3
 func KBenchmarkDecodeSumVec3(_ uint32) float32 {
-	var sum km.Vec3
+	var sum float32
 	monsters := _Struct.Monsters
 	for i := range monsters {
 		path := monsters[i].Data.Path
 		for i := range path {
-			sum.X += path[i].X
-			sum.Y += path[i].Y
-			sum.Z += path[i].Z
+			sum += path[i].X + path[i].Y + path[i].Z
 		}
 	}
 
-	return sum.X + sum.Y + sum.Z
+	return sum
 }

--- a/benchmark/main_test.go
+++ b/benchmark/main_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -21,7 +20,6 @@ func TestDecodeObjectAPI(t *testing.T) {
 	_Struct = KStruct
 	decoded := decode(encode())
 	if !reflect.DeepEqual(decoded, KStruct) {
-		fmt.Println(decoded)
 		t.Error("not match")
 	}
 }

--- a/benchmark/main_wasi_bench_km_test.go
+++ b/benchmark/main_wasi_bench_km_test.go
@@ -1,0 +1,91 @@
+//go:build (wazero || wasmer || tcp) && !nobench && km
+// +build wazero wasmer tcp
+// +build !nobench
+// +build km
+
+package main
+
+import (
+	"testing"
+
+	"benchmark.karmem.org/km"
+	karmem "karmem.org/golang"
+)
+
+func init() {
+	initEncode()
+}
+
+func BenchmarkDecodeSumUint8(b *testing.B) {
+	m := initBridge(b, "KBenchmarkEncodeObjectAPI", "KBenchmarkDecodeObjectAPI", "KBenchmarkDecodeSumUint8")
+	defer m.Close()
+	encoded := encode()
+	m.Write(encoded)
+	m.Run(FunctionKBenchmarkDecodeObjectAPI, uint64(len(encoded)))
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	l := uint64(len(encoded))
+	for i := 0; i < b.N; i++ {
+		n, err := m.Run(FunctionKBenchmarkDecodeSumUint8, l)
+		if err != nil {
+			b.Fatal("x", err)
+		}
+		if uint32(n[0]) != KSumInventoryExpected {
+			b.Error("invalid sum", n, KSumInventoryExpected)
+		}
+	}
+}
+
+func BenchmarkDecodeSumStats(b *testing.B) {
+	m := initBridge(b, "KBenchmarkEncodeObjectAPI", "KBenchmarkDecodeObjectAPI", "KBenchmarkDecodeSumStats")
+	defer m.Close()
+	encoded := encode()
+	m.Write(encoded)
+	m.Run(FunctionKBenchmarkDecodeObjectAPI, uint64(len(encoded)))
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	l := uint64(len(encoded))
+	for i := 0; i < b.N; i++ {
+		n, err := m.Run(FunctionKBenchmarkDecodeSumStats, l)
+		if err != nil {
+			b.Fatal("x", err)
+		}
+
+		result := km.NewWeaponDataViewer(karmem.NewReader(m.Reader(uint32(n[0]))), 0)
+
+		if n := result.Damage(); n != KSumWeaponStatus.Damage {
+			b.Error("invalid sum", n, KSumWeaponStatus.Damage)
+		}
+
+		if n := result.Range(); n != KSumWeaponStatus.Range {
+			b.Error("invalid sum", n, KSumWeaponStatus.Range)
+		}
+
+		if n := result.Ammo(); n != KSumWeaponStatus.Ammo {
+			b.Error("invalid sum", n, KSumWeaponStatus.Ammo)
+		}
+
+		if n := result.ClipSize(); n != KSumWeaponStatus.ClipSize {
+			b.Error("invalid sum", n, KSumWeaponStatus.ClipSize)
+		}
+	}
+}
+
+func BenchmarkNoOp(b *testing.B) {
+	m := initBridge(b, "KBenchmarkEncodeObjectAPI", "KNOOP")
+	defer m.Close()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		n, err := m.Run(FunctionKNOOP)
+		if err != nil {
+			b.Fatal("x", err)
+		}
+		if uint32(n[0]) != 42 {
+			b.Error("invalid no-op value")
+		}
+	}
+}

--- a/benchmark/main_wasi_test_test.go
+++ b/benchmark/main_wasi_test_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/r3labs/diff/v3"
@@ -51,8 +50,6 @@ func TestEncodeObjectAPI(t *testing.T) {
 
 	if len(changes) > 0 {
 		for _, x := range changes {
-			fmt.Println(result.Monsters[0].Data.Path)
-			fmt.Println(expected.Monsters[0].Data.Path)
 			t.Error(x.Type, x.Path)
 		}
 		t.Fatal("changes detected")

--- a/benchmark/main_wasi_test_test.go
+++ b/benchmark/main_wasi_test_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/r3labs/diff/v3"
@@ -50,6 +51,8 @@ func TestEncodeObjectAPI(t *testing.T) {
 
 	if len(changes) > 0 {
 		for _, x := range changes {
+			fmt.Println(result.Monsters[0].Data.Path)
+			fmt.Println(expected.Monsters[0].Data.Path)
 			t.Error(x.Type, x.Path)
 		}
 		t.Fatal("changes detected")

--- a/benchmark/main_wasi_wazero.go
+++ b/benchmark/main_wasi_wazero.go
@@ -128,7 +128,10 @@ func (w *WasmWazero) Write(b []byte) bool {
 }
 
 func (w *WasmWazero) Reader(l uint32) []byte {
-	out, _ := w.mainModule.Memory().Read(context.Background(), uint32(w.output), l)
+	out, ok := w.mainModule.Memory().Read(context.Background(), uint32(w.output), l)
+	if !ok {
+		return nil
+	}
 	return out
 }
 
@@ -145,5 +148,10 @@ func (w *WasmWazero) Run(s Functions, v ...uint64) ([]uint64, error) {
 }
 
 func (w *WasmWazero) Close() error {
-	return w.runtime.Close(context.Background())
+	err := w.runtime.Close(context.Background())
+	if err != nil {
+		return err
+	}
+	*w = WasmWazero{}
+	return nil
 }

--- a/benchmark/swift/main.swift
+++ b/benchmark/swift/main.swift
@@ -2,7 +2,7 @@ import karmem
 import km
 
 var InputMemory: [UInt8] = Array(repeating: 0, count: 8_000_000)
-var OutputMemory: [UInt8] = Array(repeating: 0, count: 8_000_001)
+var OutputMemory: [UInt8] = Array(repeating: 0, count: 8_000_000)
 
 @_cdecl("InputMemoryPointer")
 func InputMemoryPointer() -> UInt32 {
@@ -14,43 +14,98 @@ func OutputMemoryPointer() -> UInt32 {
     return UInt32(Int(bitPattern: OutputMemory.withUnsafeBufferPointer({ return UnsafePointer($0.baseAddress!) })))
 }
 
-var _KarmemStruct: km.Monsters = km.Monsters()
-var _KarmemWriter = karmem.NewFixedWriter(OutputMemory)
-var _KarmemReader = karmem.NewReader(InputMemory)
+var _Struct = km.Monsters()
+var _Writer = karmem.NewFixedWriter(OutputMemory)
+var _Reader = karmem.NewReader(InputMemory)
 
 @_cdecl("KBenchmarkEncodeObjectAPI")
 func KBenchmarkEncodeObjectAPI() {
-    _KarmemWriter.Reset()
-    _ = _KarmemStruct.WriteAsRoot(&_KarmemWriter)
+    _Writer.Reset()
+    _ = _Struct.WriteAsRoot(&_Writer)
 }
 
 @_cdecl("KBenchmarkDecodeObjectAPI")
 func KBenchmarkDecodeObjectAPI(_ size: UInt32) {
-    _ = _KarmemReader.SetSize(size)
-    _KarmemStruct.ReadAsRoot(_KarmemReader)
+    _ = _Reader.SetSize(size)
+    _Struct.ReadAsRoot(_Reader)
 }
 
 @_cdecl("KBenchmarkDecodeSumVec3")
-func KBenchmarkDecodeSumVec3(_ size: UInt32) -> Float {
-    _ = _KarmemReader.SetSize(size)
+func KBenchmarkDecodeSumVec3(_ size: UInt32) -> Float32 {
+    _ = _Reader.SetSize(size)
 
-    let monsters = km.NewMonstersViewer(_KarmemReader, 0)
-    var monstersList = monsters.Monsters(_KarmemReader)
+    let monsters = km.NewMonstersViewer(_Reader, 0)
+    var monstersList = monsters.Monsters(_Reader)
 
-    var sum = km.Vec3()
+    var sum: Float32 = 0.0
     var i: Int = 0
     while (i < monstersList.count) {
-        var path = monstersList[i].Data(_KarmemReader).Path(_KarmemReader)
+        var path = monstersList[i].Data(_Reader).Path(_Reader)
         var p: Int = 0
         while (p < path.count) {
             let pp = path[p]
-            sum.X += pp.X()
-            sum.Y += pp.Y()
-            sum.Z += pp.Z()
+            sum += (pp.X() + pp.Y() + pp.Z())
             p += 1
         }
         i += 1
     }
-    return sum.X + sum.Y + sum.Z
+    return sum
 }
 
+@_cdecl("KBenchmarkDecodeSumUint8")
+func KBenchmarkDecodeSumUint8(_ size: UInt32) -> UInt32 {
+    _ = _Reader.SetSize(size)
+
+    let monsters = km.NewMonstersViewer(_Reader, 0)
+    var monstersList = monsters.Monsters(_Reader)
+
+	var sum: UInt32 = 0
+    var i: Int = 0
+    while (i < monstersList.count) {
+		var inv = monstersList[i].Data(_Reader).Inventory(_Reader)
+
+        var j: Int = 0
+        while (j < inv.count) {
+			sum &+= UInt32(inv[j])
+			j += 1
+		}
+		i += 1
+	}
+
+	return sum
+}
+
+@_cdecl("KBenchmarkDecodeSumStats")
+func KBenchmarkDecodeSumStats(_ size: UInt32) -> UInt32 {
+	_ = _Reader.SetSize(size)
+
+	let monsters = km.NewMonstersViewer(_Reader, 0)
+	var monstersList = monsters.Monsters(_Reader)
+
+	var sum: km.WeaponData = km.NewWeaponData()
+	var i: Int = 0
+    while (i < monstersList.count) {
+		var weapons = monstersList[i].Data(_Reader).Weapons()
+
+        var j: Int = 0
+        while (j < weapons.count) {
+			let data = weapons[j].Data(_Reader)
+			sum.Ammo &+= data.Ammo()
+			sum.Damage &+= data.Damage()
+			sum.ClipSize &+= data.ClipSize()
+			sum.ReloadTime += data.ReloadTime()
+			sum.Range &+= data.Range()
+			j += 1
+		}
+		i += 1
+	}
+
+	_Writer.Reset()
+	_ = sum.WriteAsRoot(&_Writer)
+	return 8_000_000
+}
+
+@_cdecl("KNOOP")
+func KNOOP() -> UInt32 {
+	return 42
+}

--- a/benchmark/testdata/game.fbs
+++ b/benchmark/testdata/game.fbs
@@ -12,6 +12,9 @@ struct Vec3 {
 
 table Weapon {
     damage: int;
+    ammo uint16;
+    clip_size uint8;
+    reload_time float32;
     range:  int;
 }
 

--- a/benchmark/testdata/game.km
+++ b/benchmark/testdata/game.km
@@ -12,7 +12,8 @@ struct Vec3 inline {
 
 struct WeaponData table {
     Damage int32;
-    ClipSize int16;
+    Ammo uint16;
+    ClipSize uint8;
     ReloadTime float32;
     Range  int32;
 }

--- a/benchmark/testdata/game.km
+++ b/benchmark/testdata/game.km
@@ -1,4 +1,4 @@
-karmem game @golang.package(`km`) @dotnet.package(`km`) @odin.import(`../../odin/karmem`) @assemblyscript.import(`../../assemblyscript/karmem`) @c.import(`../../c/karmem.h`);
+karmem game @packed(true) @golang.package(`km`) @dotnet.package(`km`) @odin.import(`../../odin/karmem`) @assemblyscript.import(`../../assemblyscript/karmem`) @c.import(`../../c/karmem.h`);
 
 enum Color uint8 {Red;Green;Blue;}
 
@@ -12,6 +12,8 @@ struct Vec3 inline {
 
 struct WeaponData table {
     Damage int32;
+    ClipSize int16;
+    ReloadTime float32;
     Range  int32;
 }
 

--- a/cmd/karmem/kmgen/assemblyscript_template.astmpl
+++ b/cmd/karmem/kmgen/assemblyscript_template.astmpl
@@ -84,7 +84,9 @@ export class {{$root.Data.Name}} {
         writer.WriteAt<u32>(offset +{{$field.Data.Offset}}, __{{$field.Data.Name}}Offset);
         {{- if $field.Data.Type.IsSlice}}
         writer.WriteAt<u32>(offset +{{$field.Data.Offset}} +4, __{{$field.Data.Name}}Size);
+        {{- if not $root.Data.Packed }}
         writer.WriteAt<u32>(offset + {{$field.Data.Offset}} + 4 + 4, {{$field.Data.Size.Allocation}})
+        {{- end }}
         {{- end}}
         {{- end }}
         {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum }}
@@ -248,7 +250,7 @@ export function New{{$root.Data.Name}}(): {{$root.Data.Name}} {
 @unmanaged
 export class {{$root.Data.Name}}Viewer {
     {{- range $key, $padding := $root.Data.Size.TotalGroup }}
-    private _{{$key}}: u64;
+    private _{{$key}}: {{ToType $padding.Data}};
     {{- end}}
 
     @inline

--- a/cmd/karmem/kmgen/c_template.ctmpl
+++ b/cmd/karmem/kmgen/c_template.ctmpl
@@ -90,8 +90,10 @@ uint32_t {{$root.Data.Name}}Write({{$root.Data.Name}} * x, KarmemWriter * writer
     KarmemWriterWriteAt(writer, offset+{{$field.Data.Offset}}, (void *) &__{{$field.Data.Name}}Offset, 4);
     {{- if $field.Data.Type.IsSlice}}
     KarmemWriterWriteAt(writer, offset+{{$field.Data.Offset}}+4, (void *) &__{{$field.Data.Name}}Size, 4);
+    {{- if not $root.Data.Packed }}
     uint32_t __{{$field.Data.Name}}SizeEach = {{$field.Data.Size.Allocation}};
     KarmemWriterWriteAt(writer, offset+{{$field.Data.Offset}}+4+4, (void *) &__{{$field.Data.Name}}SizeEach, 4);
+    {{- end }}
     {{- end }}
 {{- end }}
 {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum }}
@@ -233,9 +235,11 @@ void {{$root.Data.Name}}Reset({{$root.Data.Name}} * x) {
     {{- /*gotype: karmem.org/cmd/karmem/kmparser.File*/ -}}
     {{- range $root := .Structs}}
 
-typedef struct {
+#pragma pack(1)
+typedef struct __attribute__((packed)) {
     uint8_t _data[{{$root.Data.Size.Total}}];
 } {{$root.Data.Name}}Viewer;
+#pragma options align=reset
 
 uint32_t {{$root.Data.Name}}ViewerSize({{$root.Data.Name}}Viewer * x) {
 {{- if $root.Data.IsTable}}

--- a/cmd/karmem/kmgen/dotnet_template.dotnettmpl
+++ b/cmd/karmem/kmgen/dotnet_template.dotnettmpl
@@ -121,7 +121,9 @@ public unsafe struct {{$root.Data.Name}} {
                 {{- if (not $field.Data.Type.IsString)}}
         writer.WriteAt(offset+{{$field.Data.Offset}} + 4, (uint)__{{$field.Data.Name}}Size);
                 {{- end}}
+            {{- if not $root.Data.Packed }}
         writer.WriteAt(offset+{{$field.Data.Offset}} + 4 + 4, (uint){{$field.Data.Size.Allocation}});
+            {{- end }}
             {{- end }}
         {{- end }}
         {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum }}
@@ -252,10 +254,10 @@ public unsafe struct {{$root.Data.Name}} {
 {{define "struct_builder"}}
     {{- /*gotype: karmem.org/cmd/karmem/kmparser.File*/ -}}
     {{- range $root := .Structs}}
-[StructLayout(LayoutKind.Sequential, Pack=0, Size={{$root.Data.Size.Total}})]
+[StructLayout(LayoutKind.Sequential, Pack=1, Size={{$root.Data.Size.Total}})]
 public unsafe struct {{$root.Data.Name}}Viewer {
     {{- range $key, $padding := $root.Data.Size.TotalGroup }}
-    private readonly long _{{$key}};
+    private readonly {{ToType $padding.Data}} _{{$key}};
     {{- end}}
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/cmd/karmem/kmgen/golang_template.gotmpl
+++ b/cmd/karmem/kmgen/golang_template.gotmpl
@@ -101,7 +101,9 @@
                 writer.Write4At(offset+{{$field.Data.Offset}}, uint32(__{{$field.Data.Name}}Offset))
                 {{- if $field.Data.Type.IsSlice}}
                     writer.Write4At(offset+{{$field.Data.Offset}} + 4, uint32(__{{$field.Data.Name}}Size))
+                        {{- if not $root.Data.Packed }}
                     writer.Write4At(offset+{{$field.Data.Offset}} + 4 + 4, {{$field.Data.Size.Allocation}})
+                        {{- end}}
                 {{- end }}
             {{- end }}
             {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum }}
@@ -239,9 +241,7 @@
 {{define "struct_builder"}}
     {{- /*gotype: karmem.org/cmd/karmem/kmparser.File*/ -}}
     {{- range $root := .Structs}}
-        type {{$root.Data.Name}}Viewer struct {
-        _data [{{$root.Data.Size.Total}}]byte
-        }
+        type {{$root.Data.Name}}Viewer [{{$root.Data.Size.Total}}]byte
 
         func New{{$root.Data.Name}}Viewer(reader *karmem.Reader, offset uint32) (v *{{$root.Data.Name}}Viewer) {
         if !reader.IsValidOffset(offset, {{$root.Data.Size.Minimum}}) {
@@ -258,7 +258,7 @@
 
         func (x *{{$root.Data.Name}}Viewer) size() uint32 {
         {{- if $root.Data.IsTable}}
-            return *(*uint32)(unsafe.Pointer(&x._data))
+            return *(*uint32)(unsafe.Pointer(x))
         {{- else}}
             return {{$root.Data.Size.Total}}
         {{- end }}
@@ -283,20 +283,20 @@
             {{- if $field.Data.Type.IsInline}}
                 {{- if not $field.Data.Type.IsArray}}
                     {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum }}
-                        return *(*{{ToTypeView $field.Data.Type}})(unsafe.Add(unsafe.Pointer(&x._data), {{$field.Data.Offset}}))
+                        return *(*{{ToTypeView $field.Data.Type}})(unsafe.Add(unsafe.Pointer(x), {{$field.Data.Offset}}))
                     {{- else}}
-                        return ({{ToTypeView $field.Data.Type}})(unsafe.Add(unsafe.Pointer(&x._data), {{$field.Data.Offset}}))
+                        return ({{ToTypeView $field.Data.Type}})(unsafe.Add(unsafe.Pointer(x), {{$field.Data.Offset}}))
                     {{- end}}
                 {{- else}}
                     slice := [3]uintptr{
-                    uintptr(unsafe.Add(unsafe.Pointer(&x._data), {{$field.Data.Offset}})), {{$field.Data.Type.Length}}, {{$field.Data.Type.Length}},
+                    uintptr(unsafe.Add(unsafe.Pointer(x), {{$field.Data.Offset}})), {{$field.Data.Type.Length}}, {{$field.Data.Type.Length}},
                     }
                     return *(*{{ToTypeView $field.Data.Type}})(unsafe.Pointer(&slice))
                 {{- end}}
             {{- else }}
-                offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), {{$field.Data.Offset}}))
+                offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), {{$field.Data.Offset}}))
                 {{- if $field.Data.Type.IsSlice}}
-                    size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), {{$field.Data.Offset}} + 4))
+                    size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), {{$field.Data.Offset}} + 4))
                     if !reader.IsValidOffset(offset, size) {
                     {{- if $field.Data.Type.IsString }}
                         return ""

--- a/cmd/karmem/kmgen/km_template.kmtmpl
+++ b/cmd/karmem/kmgen/km_template.kmtmpl
@@ -1,4 +1,4 @@
-{{- define "header"}}karmem {{.Name}} {{- range $tag := .Tags }} @{{$tag.Name}}(`{{$tag.Value}}`){{- end }};
+{{- define "header"}}karmem {{.Name}} {{- range $tag := .Tags }} @{{$tag.Name}}({{- if $tag.Value}}`{{$tag.Value}}`{{- end}}){{- end }};
 {{end}}
 {{- define "enums"}}
 {{- /*gotype: karmem.org/cmd/karmem/kmparser.File*/ -}}
@@ -6,11 +6,11 @@
 enum {{$root.Data.Name}} {{$root.Data.Type.Schema}}{{range $tag := $root.Data.Tags }} @{{$tag.Name}}(`{{$tag.Value}}`){{ end }} {
 {{- if $root.Data.IsSequential}}
     {{- range $field := $root.Data.Fields}}
-    {{$field.Data.Name}} {{- range $tag := $field.Data.Tags }} @{{$tag.Name}}(`{{$tag.Value}}`){{ end }};
+    {{ToNamePadding $field $root}} {{- range $tag := $field.Data.Tags }} @{{$tag.Name}}({{- if $tag.Value}}`{{$tag.Value}}`{{- end}}){{ end }};
     {{- end}}
 {{- else}}
     {{- range $field := $root.Data.Fields}}
-    {{$field.Data.Name}} = {{$field.Data.Value}} {{- range $tag := $field.Data.Tags }} @{{$tag.Name}}(`{{$tag.Value}}`){{ end }};
+    {{ToNamePadding $field $root}} = {{$field.Data.Value}} {{- range $tag := $field.Data.Tags }} @{{$tag.Name}}({{- if $tag.Value}}`{{$tag.Value}}`{{- end}}){{ end }};
     {{- end}}
 {{- end}}
 }
@@ -18,9 +18,9 @@ enum {{$root.Data.Name}} {{$root.Data.Type.Schema}}{{range $tag := $root.Data.Ta
 {{ end }}
 {{- define "struct"}}
 {{- range $root := .Structs}}
-struct {{$root.Data.Name}} {{FromStructClass $root.Data.Class}}{{range $tag := $root.Data.Tags }} @{{$tag.Name}}(`{{$tag.Value}}`){{ end }} {
+struct {{$root.Data.Name}} {{FromStructClass $root.Data.Class}}{{range $tag := $root.Data.Tags }} @{{$tag.Name}}({{- if $tag.Value}}`{{$tag.Value}}`{{- end}}){{ end }} {
     {{- range $field := $root.Data.Fields}}
-    {{ToNamePadding $field $root}} {{$field.Data.Type.Schema}} {{- range $tag := $field.Data.Tags }} @{{$tag.Name}}(`{{$tag.Value}}`){{ end }};
+    {{ToNamePadding $field $root}} {{$field.Data.Type.Schema}} {{- range $tag := $field.Data.Tags }} @{{$tag.Name}}({{- if $tag.Value}}`{{$tag.Value}}`{{- end}}){{ end }};
     {{- end}}
 }
 {{ end }}

--- a/cmd/karmem/kmgen/kmgen.go
+++ b/cmd/karmem/kmgen/kmgen.go
@@ -100,6 +100,9 @@ func NewTemplateFunctions(gen Generator, content *kmparser.Content) TemplateFunc
 			case kmparser.EnumField:
 				name = strings.TrimSpace(val.Data.Name)
 				root := root.(kmparser.Enumeration)
+				if root.Data.IsSequential {
+					return name
+				}
 				for i := range root.Data.Fields {
 					if l := len(root.Data.Fields[i].Data.Name); l > largest {
 						largest = l

--- a/cmd/karmem/kmgen/kmgen_test.go
+++ b/cmd/karmem/kmgen/kmgen_test.go
@@ -2,12 +2,13 @@ package kmgen
 
 import (
 	"bytes"
-	"karmem.org/cmd/karmem/kmparser"
 	"os"
 	"testing"
+
+	"karmem.org/cmd/karmem/kmparser"
 )
 
-func TestGolangGenerator(t *testing.T) {
+func TestGenerator(t *testing.T) {
 	path := []string{"testdata/basic.km", "testdata/paths.km"}
 	for _, path := range path {
 		f, err := os.Open(path)
@@ -20,6 +21,10 @@ func TestGolangGenerator(t *testing.T) {
 		k, err := r.Parser()
 		if err != nil {
 			t.Error(err)
+		}
+
+		if len(Generators) == 0 {
+			t.Error("no generator found")
 		}
 
 		for _, gen := range Generators {
@@ -43,6 +48,51 @@ func TestGolangGenerator(t *testing.T) {
 					t.Error(err)
 					return
 				}
+			}
+		}
+	}
+}
+
+func TestFormatter(t *testing.T) {
+	path := []string{"testdata/basic.km", "testdata/paths.km"}
+	for _, path := range path {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Error(f)
+			return
+		}
+
+		r := kmparser.NewReader(path, f)
+		k, err := r.Parser()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(Generators) == 0 {
+			t.Error("no generator found")
+		}
+
+		gen := KarmemSchemaGenerator()
+		compiler, err := gen.Start(k)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		for _, c := range compiler.Template {
+			var buffer bytes.Buffer
+			var output bytes.Buffer
+
+			for _, n := range compiler.Modules {
+				if err := c.ExecuteTemplate(&buffer, n, k); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+
+			if err := gen.Finish(&output, &buffer); err != nil {
+				t.Error(err)
+				return
 			}
 		}
 	}

--- a/cmd/karmem/kmgen/odin_template.odintmpl
+++ b/cmd/karmem/kmgen/odin_template.odintmpl
@@ -90,7 +90,9 @@ New{{$root.Data.Name}} :: #force_inline proc() -> {{$root.Data.Name}} #no_bounds
     karmem.WriterWrite4At(writer, offset+{{$field.Data.Offset}}, u32(__{{$field.Data.Name}}Offset))
         {{- if $field.Data.Type.IsSlice}}
     karmem.WriterWrite4At(writer, offset+{{$field.Data.Offset}} + 4, u32(__{{$field.Data.Name}}Size))
+    {{- if not $root.Data.Packed }}
     karmem.WriterWrite4At(writer, offset+{{$field.Data.Offset}} + 4 + 4, {{$field.Data.Size.Allocation}})
+    {{- end }}
         {{- end }}
         {{- end }}
         {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum }}

--- a/cmd/karmem/kmgen/swift_template.swifttmpl
+++ b/cmd/karmem/kmgen/swift_template.swifttmpl
@@ -120,7 +120,9 @@ public struct {{$root.Data.Name}} {
         writer.memory.storeBytes(of: UInt32(__{{$field.Data.Name}}Offset), toByteOffset: Int(offset + {{$field.Data.Offset}}), as: UInt32.self)
             {{- if $field.Data.Type.IsSlice }}
         writer.memory.storeBytes(of: UInt32(__{{$field.Data.Name}}Size), toByteOffset: Int(offset + {{$field.Data.Offset}} + 4), as: UInt32.self)
+            {{- if not $root.Data.Packed }}
         writer.memory.storeBytes(of: UInt32({{$field.Data.Size.Allocation}}), toByteOffset: Int(offset + {{$field.Data.Offset}} + 4 + 4), as: UInt32.self)
+            {{- end }}
             {{- end}}
         {{- end }}
         {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum }}

--- a/cmd/karmem/kmgen/testdata/basic.km
+++ b/cmd/karmem/kmgen/testdata/basic.km
@@ -1,6 +1,46 @@
 karmem demo @golang.package(demo);
 
-struct SimpleNumbers table {
+enum XA uint8 {
+    AAAAAAAAAA = 0;
+    B;
+}
+
+enum XB uint16 {
+    A;
+    BBBBBBBBBBBBBBBBBBBBBBBB = 100;
+}
+
+enum XC uint32 {
+    AAAAAAAA                            ;
+    BBBBBBBBBBBBBBBBBBBBB =                           10;
+}
+
+enum XD uint64 @tag() @foo() @bar() {
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA = 0;
+    BBBBBBBBB = 10000000;
+}
+
+enum IA int8 {
+    A = 0;
+    B = 1;
+}
+
+enum IB int16 @a() @b() {
+A;
+    BBBBBBBBBBBBBBBB = 300;
+}
+
+enum IC int32 {
+    A;
+    B;
+}
+
+enum ID int64 {
+    A;
+    B;
+}
+
+struct SimpleNumbers inline {
     N8 uint8;
     N16 uint16;
     N32 uint32;
@@ -13,4 +53,103 @@ struct SimpleNumbers table {
 
     OF32 float32;
     OF64 float64;
+
+    B1 bool;
+
+    NN8 []uint8;
+    NN16 []uint16;
+    NN32 []uint32;
+    NN64 []uint64;
+
+    NM8 []int8;
+    NM16 []int16;
+    NM32 []int32;
+    NM64 []int64;
+
+    NOF32 []float32;
+    NOF64 []float64;
+}
+
+struct SimpleNumbersPacked inline @packed() {
+    N8 uint8;
+    N16 uint16;
+    N32 uint32;
+    N64 uint64;
+
+    M8 int8;
+    M16 int16;
+    M32 int32;
+    M64 int64;
+
+    OF32 float32;
+    OF64 float64;
+
+    B1 bool;
+
+    NN8 []uint8;
+    NN16 []uint16;
+    NN32 []uint32;
+    NN64 []uint64;
+
+    NM8 []int8;
+    NM16 []int16;
+    NM32 []int32;
+    NM64 []int64;
+
+    NOF32 []float32;
+    NOF64 []float64;
+}
+
+struct ComplexPacked table @packed() {
+           N8 uint8;
+    N16 uint16;
+    N32 uint32;
+           N64 uint64;
+
+    M8 int8;
+    M16 int16;
+           M32 int32;
+    M64 int64;
+
+           OF32 float32;
+    OF64 float64;
+
+    B1 bool;
+
+    NN8 []uint8;
+    NN16 []uint16;
+           NN32 []uint32;
+              NN64 []uint64;
+
+    NM8 []int8;
+    NM16 []int16;
+    NM32 []int32;
+    NM64 []int64;
+
+    NOF32 []float32;
+    NOF64 []float64;
+
+    NB []bool;
+    NC []char;
+             NIL []SimpleNumbers;
+    NIP []SimpleNumbersPacked;
+    
+
+ANN8 [64]uint8;
+ANN16 [64]uint16;
+ANN32 [64]uint32;
+ANN64 [64]uint64;
+
+ANM8 [64]int8;
+ANM16 [64]int16;
+ANM32 [64]int32;
+ANM64 [64]int64;
+
+ANOF32 [64]float32;
+ANOF64 [64]float64;
+
+ANB [64]bool;
+ANC [64]char;
+ANIL [64]SimpleNumbers;
+ANIP [64]SimpleNumbersPacked;
 }

--- a/cmd/karmem/kmgen/zig_template.zigtmpl
+++ b/cmd/karmem/kmgen/zig_template.zigtmpl
@@ -89,8 +89,10 @@ pub const {{$root.Data.Name}} = struct {
         karmem.Writer.WriteAt(writer, offset+{{$field.Data.Offset}}, @ptrCast([*]const u8, &__{{$field.Data.Name}}Offset), 4);
         {{- if $field.Data.Type.IsSlice}}
         karmem.Writer.WriteAt(writer, offset+{{$field.Data.Offset}}+4, @ptrCast([*]const u8, &__{{$field.Data.Name}}Size), 4);
+            {{- if not $root.Data.Packed}}
         var __{{$field.Data.Name}}SizeEach: u32 = {{$field.Data.Size.Allocation}};
         karmem.Writer.WriteAt(writer, offset+{{$field.Data.Offset}}+4+4, @ptrCast([*]const u8, &__{{$field.Data.Name}}SizeEach), 4);
+            {{- end}}
         {{- end }}
     {{- end }}
     {{- if or $field.Data.Type.IsNative $field.Data.Type.IsEnum }}
@@ -228,7 +230,7 @@ pub fn New{{$root.Data.Name}}() {{$root.Data.Name}} {
     {{- /*gotype: karmem.org/cmd/karmem/kmparser.File*/ -}}
     {{- range $root := .Structs}}
 
-pub const {{$root.Data.Name}}Viewer = struct {
+pub const {{$root.Data.Name}}Viewer = extern struct {
     _data: [{{$root.Data.Size.Total}}]u8,
 
     pub fn Size(x: *const {{$root.Data.Name}}Viewer) u32 {

--- a/cmd/karmem/kmparser/kmgen.km
+++ b/cmd/karmem/kmparser/kmgen.km
@@ -1,4 +1,4 @@
-karmem kmparser;
+karmem kmparser @packed();
 
 enum StructClass uint8 {
     None;
@@ -23,6 +23,18 @@ enum TypeFormat uint8 {
 }
 
 
+struct Type table @id(`2206764383142231373`) {
+    Schema      []char;
+    PlainSchema []char;
+    Length      uint32;
+    Format      TypeFormat;
+    Model       TypeModel;
+}
+
+struct PaddingType inline @id(`6449815373135188035`) {
+    Data Type;
+}
+
 struct Tag inline @id(`9280816983786621498`) {
     Name  []char;
     Value []char;
@@ -33,21 +45,13 @@ struct StructSize table @id(`2296279785726396957`) {
     Content    uint32;
     Padding    uint32;
     Total      uint32;
-    TotalGroup []uint8;
+    TotalGroup []PaddingType;
 }
 
 struct StructFieldSize table @id(`3117293985139574571`) {
     Minimum    uint32;
     Allocation uint32;
     Field      uint32;
-}
-
-struct Type table @id(`2206764383142231373`) {
-    Schema      []char;
-    PlainSchema []char;
-    Length      uint32;
-    Format      TypeFormat;
-    Model       TypeModel;
 }
 
 struct EnumFieldData table @id(`6917629752752470509`) {
@@ -91,6 +95,7 @@ struct StructData table @id(`8290009745541165076`) {
     Fields []StructField;
     Class  StructClass;
     Tags   []Tag;
+    Packed bool;
 }
 
 struct Structure inline @id(`18088017590773436939`) {
@@ -113,4 +118,5 @@ struct Content table @id(`6792576797909524956`) {
     Enums   []Enumeration;
     Size    ContentSize;
     Name    []char;
+    Packed  bool;
 }

--- a/cmd/karmem/kmparser/kmparser_extension.go
+++ b/cmd/karmem/kmparser/kmparser_extension.go
@@ -1,5 +1,9 @@
 package kmparser
 
+import (
+	"fmt"
+)
+
 type Tags []Tag
 
 func (x Tags) Get(s string) (string, bool) {
@@ -9,6 +13,24 @@ func (x Tags) Get(s string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func (x Tags) GetBoolean(s string) (r int, err error) {
+	for i := range x {
+		if x[i].Name == s {
+			switch x[i].Value {
+			case "":
+				fallthrough
+			case "true":
+				return 1, nil
+			case "false":
+				return 0, nil
+			default:
+				return -1, fmt.Errorf(`invalid value of "%s" for %s`, x[i].Value, x[i].Name)
+			}
+		}
+	}
+	return -1, nil
 }
 
 func (x *Type) IsBasic() bool {

--- a/cmd/karmem/kmparser/kmparser_generated.go
+++ b/cmd/karmem/kmparser/kmparser_generated.go
@@ -1,14 +1,13 @@
 package kmparser
 
 import (
-	"unsafe"
-
 	karmem "karmem.org/golang"
+	"unsafe"
 )
 
 var _ unsafe.Pointer
 
-var _Null = make([]byte, 64)
+var _Null = make([]byte, 42)
 var _NullReader = karmem.NewReader(_Null)
 
 type (
@@ -50,10 +49,11 @@ type (
 )
 
 const (
+	PacketIdentifierType            = 2206764383142231373
+	PacketIdentifierPaddingType     = 6449815373135188035
 	PacketIdentifierTag             = 9280816983786621498
 	PacketIdentifierStructSize      = 2296279785726396957
 	PacketIdentifierStructFieldSize = 3117293985139574571
-	PacketIdentifierType            = 2206764383142231373
 	PacketIdentifierEnumFieldData   = 6917629752752470509
 	PacketIdentifierEnumField       = 18350873289003309128
 	PacketIdentifierEnumData        = 18057555498029063613
@@ -64,8 +64,142 @@ const (
 	PacketIdentifierStructure       = 18088017590773436939
 	PacketIdentifierContentSize     = 8764462619562198222
 	PacketIdentifierContentOptions  = 12347233001904861813
-	PacketIdentifierContent         = 2
+	PacketIdentifierContent         = 6792576797909524956
 )
+
+type Type struct {
+	Schema      string
+	PlainSchema string
+	Length      uint32
+	Format      TypeFormat
+	Model       TypeModel
+}
+
+func NewType() Type {
+	return Type{}
+}
+
+func (x *Type) PacketIdentifier() PacketIdentifier {
+	return PacketIdentifierType
+}
+
+func (x *Type) Reset() {
+	x.Read((*TypeViewer)(unsafe.Pointer(&_Null)), _NullReader)
+}
+
+func (x *Type) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
+	return x.Write(writer, 0)
+}
+
+func (x *Type) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
+	offset = start
+	size := uint(26)
+	if offset == 0 {
+		offset, err = writer.Alloc(size)
+		if err != nil {
+			return 0, err
+		}
+	}
+	writer.Write4At(offset, uint32(26))
+	__SchemaSize := uint(1 * len(x.Schema))
+	__SchemaOffset, err := writer.Alloc(__SchemaSize)
+	if err != nil {
+		return 0, err
+	}
+	writer.Write4At(offset+4, uint32(__SchemaOffset))
+	writer.Write4At(offset+4+4, uint32(__SchemaSize))
+	__SchemaSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Schema)), __SchemaSize, __SchemaSize}
+	writer.WriteAt(__SchemaOffset, *(*[]byte)(unsafe.Pointer(&__SchemaSlice)))
+	__PlainSchemaSize := uint(1 * len(x.PlainSchema))
+	__PlainSchemaOffset, err := writer.Alloc(__PlainSchemaSize)
+	if err != nil {
+		return 0, err
+	}
+	writer.Write4At(offset+12, uint32(__PlainSchemaOffset))
+	writer.Write4At(offset+12+4, uint32(__PlainSchemaSize))
+	__PlainSchemaSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.PlainSchema)), __PlainSchemaSize, __PlainSchemaSize}
+	writer.WriteAt(__PlainSchemaOffset, *(*[]byte)(unsafe.Pointer(&__PlainSchemaSlice)))
+	__LengthOffset := offset + 20
+	writer.Write4At(__LengthOffset, *(*uint32)(unsafe.Pointer(&x.Length)))
+	__FormatOffset := offset + 24
+	writer.Write1At(__FormatOffset, *(*uint8)(unsafe.Pointer(&x.Format)))
+	__ModelOffset := offset + 25
+	writer.Write1At(__ModelOffset, *(*uint8)(unsafe.Pointer(&x.Model)))
+
+	return offset, nil
+}
+
+func (x *Type) ReadAsRoot(reader *karmem.Reader) {
+	x.Read(NewTypeViewer(reader, 0), reader)
+}
+
+func (x *Type) Read(viewer *TypeViewer, reader *karmem.Reader) {
+	__SchemaString := viewer.Schema(reader)
+	if x.Schema != __SchemaString {
+		__SchemaStringCopy := make([]byte, len(__SchemaString))
+		copy(__SchemaStringCopy, __SchemaString)
+		x.Schema = *(*string)(unsafe.Pointer(&__SchemaStringCopy))
+	}
+	__PlainSchemaString := viewer.PlainSchema(reader)
+	if x.PlainSchema != __PlainSchemaString {
+		__PlainSchemaStringCopy := make([]byte, len(__PlainSchemaString))
+		copy(__PlainSchemaStringCopy, __PlainSchemaString)
+		x.PlainSchema = *(*string)(unsafe.Pointer(&__PlainSchemaStringCopy))
+	}
+	x.Length = viewer.Length()
+	x.Format = TypeFormat(viewer.Format())
+	x.Model = TypeModel(viewer.Model())
+}
+
+type PaddingType struct {
+	Data Type
+}
+
+func NewPaddingType() PaddingType {
+	return PaddingType{}
+}
+
+func (x *PaddingType) PacketIdentifier() PacketIdentifier {
+	return PacketIdentifierPaddingType
+}
+
+func (x *PaddingType) Reset() {
+	x.Read((*PaddingTypeViewer)(unsafe.Pointer(&_Null)), _NullReader)
+}
+
+func (x *PaddingType) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
+	return x.Write(writer, 0)
+}
+
+func (x *PaddingType) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
+	offset = start
+	size := uint(4)
+	if offset == 0 {
+		offset, err = writer.Alloc(size)
+		if err != nil {
+			return 0, err
+		}
+	}
+	__DataSize := uint(26)
+	__DataOffset, err := writer.Alloc(__DataSize)
+	if err != nil {
+		return 0, err
+	}
+	writer.Write4At(offset+0, uint32(__DataOffset))
+	if _, err := x.Data.Write(writer, __DataOffset); err != nil {
+		return offset, err
+	}
+
+	return offset, nil
+}
+
+func (x *PaddingType) ReadAsRoot(reader *karmem.Reader) {
+	x.Read(NewPaddingTypeViewer(reader, 0), reader)
+}
+
+func (x *PaddingType) Read(viewer *PaddingTypeViewer, reader *karmem.Reader) {
+	x.Data.Read(viewer.Data(reader), reader)
+}
 
 type Tag struct {
 	Name  string
@@ -90,7 +224,7 @@ func (x *Tag) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
 
 func (x *Tag) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(32)
+	size := uint(16)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
@@ -104,7 +238,6 @@ func (x *Tag) Write(writer *karmem.Writer, start uint) (offset uint, err error) 
 	}
 	writer.Write4At(offset+0, uint32(__NameOffset))
 	writer.Write4At(offset+0+4, uint32(__NameSize))
-	writer.Write4At(offset+0+4+4, 1)
 	__NameSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Name)), __NameSize, __NameSize}
 	writer.WriteAt(__NameOffset, *(*[]byte)(unsafe.Pointer(&__NameSlice)))
 	__ValueSize := uint(1 * len(x.Value))
@@ -112,9 +245,8 @@ func (x *Tag) Write(writer *karmem.Writer, start uint) (offset uint, err error) 
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+12, uint32(__ValueOffset))
-	writer.Write4At(offset+12+4, uint32(__ValueSize))
-	writer.Write4At(offset+12+4+4, 1)
+	writer.Write4At(offset+8, uint32(__ValueOffset))
+	writer.Write4At(offset+8+4, uint32(__ValueSize))
 	__ValueSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Value)), __ValueSize, __ValueSize}
 	writer.WriteAt(__ValueOffset, *(*[]byte)(unsafe.Pointer(&__ValueSlice)))
 
@@ -145,7 +277,7 @@ type StructSize struct {
 	Content    uint32
 	Padding    uint32
 	Total      uint32
-	TotalGroup []uint8
+	TotalGroup []PaddingType
 }
 
 func NewStructSize() StructSize {
@@ -166,14 +298,14 @@ func (x *StructSize) WriteAsRoot(writer *karmem.Writer) (offset uint, err error)
 
 func (x *StructSize) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(40)
+	size := uint(28)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(32))
+	writer.Write4At(offset, uint32(28))
 	__MinimumOffset := offset + 4
 	writer.Write4At(__MinimumOffset, *(*uint32)(unsafe.Pointer(&x.Minimum)))
 	__ContentOffset := offset + 8
@@ -182,18 +314,19 @@ func (x *StructSize) Write(writer *karmem.Writer, start uint) (offset uint, err 
 	writer.Write4At(__PaddingOffset, *(*uint32)(unsafe.Pointer(&x.Padding)))
 	__TotalOffset := offset + 16
 	writer.Write4At(__TotalOffset, *(*uint32)(unsafe.Pointer(&x.Total)))
-	__TotalGroupSize := uint(1 * len(x.TotalGroup))
+	__TotalGroupSize := uint(4 * len(x.TotalGroup))
 	__TotalGroupOffset, err := writer.Alloc(__TotalGroupSize)
 	if err != nil {
 		return 0, err
 	}
 	writer.Write4At(offset+20, uint32(__TotalGroupOffset))
 	writer.Write4At(offset+20+4, uint32(__TotalGroupSize))
-	writer.Write4At(offset+20+4+4, 1)
-	__TotalGroupSlice := *(*[3]uint)(unsafe.Pointer(&x.TotalGroup))
-	__TotalGroupSlice[1] = __TotalGroupSize
-	__TotalGroupSlice[2] = __TotalGroupSize
-	writer.WriteAt(__TotalGroupOffset, *(*[]byte)(unsafe.Pointer(&__TotalGroupSlice)))
+	for i := range x.TotalGroup {
+		if _, err := x.TotalGroup[i].Write(writer, __TotalGroupOffset); err != nil {
+			return offset, err
+		}
+		__TotalGroupOffset += 4
+	}
 
 	return offset, nil
 }
@@ -210,12 +343,14 @@ func (x *StructSize) Read(viewer *StructSizeViewer, reader *karmem.Reader) {
 	__TotalGroupSlice := viewer.TotalGroup(reader)
 	__TotalGroupLen := len(__TotalGroupSlice)
 	if __TotalGroupLen > cap(x.TotalGroup) {
-		x.TotalGroup = append(x.TotalGroup, make([]uint8, __TotalGroupLen-len(x.TotalGroup))...)
+		x.TotalGroup = append(x.TotalGroup, make([]PaddingType, __TotalGroupLen-len(x.TotalGroup))...)
 	}
 	if __TotalGroupLen > len(x.TotalGroup) {
 		x.TotalGroup = x.TotalGroup[:__TotalGroupLen]
 	}
-	copy(x.TotalGroup, __TotalGroupSlice)
+	for i := 0; i < __TotalGroupLen; i++ {
+		x.TotalGroup[i].Read(&__TotalGroupSlice[i], reader)
+	}
 	x.TotalGroup = x.TotalGroup[:__TotalGroupLen]
 }
 
@@ -243,7 +378,7 @@ func (x *StructFieldSize) WriteAsRoot(writer *karmem.Writer) (offset uint, err e
 
 func (x *StructFieldSize) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(24)
+	size := uint(16)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
@@ -271,92 +406,6 @@ func (x *StructFieldSize) Read(viewer *StructFieldSizeViewer, reader *karmem.Rea
 	x.Field = viewer.Field()
 }
 
-type Type struct {
-	Schema      string
-	PlainSchema string
-	Length      uint32
-	Format      TypeFormat
-	Model       TypeModel
-}
-
-func NewType() Type {
-	return Type{}
-}
-
-func (x *Type) PacketIdentifier() PacketIdentifier {
-	return PacketIdentifierType
-}
-
-func (x *Type) Reset() {
-	x.Read((*TypeViewer)(unsafe.Pointer(&_Null)), _NullReader)
-}
-
-func (x *Type) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
-	return x.Write(writer, 0)
-}
-
-func (x *Type) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
-	offset = start
-	size := uint(40)
-	if offset == 0 {
-		offset, err = writer.Alloc(size)
-		if err != nil {
-			return 0, err
-		}
-	}
-	writer.Write4At(offset, uint32(34))
-	__SchemaSize := uint(1 * len(x.Schema))
-	__SchemaOffset, err := writer.Alloc(__SchemaSize)
-	if err != nil {
-		return 0, err
-	}
-	writer.Write4At(offset+4, uint32(__SchemaOffset))
-	writer.Write4At(offset+4+4, uint32(__SchemaSize))
-	writer.Write4At(offset+4+4+4, 1)
-	__SchemaSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Schema)), __SchemaSize, __SchemaSize}
-	writer.WriteAt(__SchemaOffset, *(*[]byte)(unsafe.Pointer(&__SchemaSlice)))
-	__PlainSchemaSize := uint(1 * len(x.PlainSchema))
-	__PlainSchemaOffset, err := writer.Alloc(__PlainSchemaSize)
-	if err != nil {
-		return 0, err
-	}
-	writer.Write4At(offset+16, uint32(__PlainSchemaOffset))
-	writer.Write4At(offset+16+4, uint32(__PlainSchemaSize))
-	writer.Write4At(offset+16+4+4, 1)
-	__PlainSchemaSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.PlainSchema)), __PlainSchemaSize, __PlainSchemaSize}
-	writer.WriteAt(__PlainSchemaOffset, *(*[]byte)(unsafe.Pointer(&__PlainSchemaSlice)))
-	__LengthOffset := offset + 28
-	writer.Write4At(__LengthOffset, *(*uint32)(unsafe.Pointer(&x.Length)))
-	__FormatOffset := offset + 32
-	writer.Write1At(__FormatOffset, *(*uint8)(unsafe.Pointer(&x.Format)))
-	__ModelOffset := offset + 33
-	writer.Write1At(__ModelOffset, *(*uint8)(unsafe.Pointer(&x.Model)))
-
-	return offset, nil
-}
-
-func (x *Type) ReadAsRoot(reader *karmem.Reader) {
-	x.Read(NewTypeViewer(reader, 0), reader)
-}
-
-func (x *Type) Read(viewer *TypeViewer, reader *karmem.Reader) {
-	__SchemaString := viewer.Schema(reader)
-	if x.Schema != __SchemaString {
-		__SchemaStringCopy := make([]byte, len(__SchemaString))
-		copy(__SchemaStringCopy, __SchemaString)
-		x.Schema = *(*string)(unsafe.Pointer(&__SchemaStringCopy))
-	}
-	__PlainSchemaString := viewer.PlainSchema(reader)
-	if x.PlainSchema != __PlainSchemaString {
-		__PlainSchemaStringCopy := make([]byte, len(__PlainSchemaString))
-		copy(__PlainSchemaStringCopy, __PlainSchemaString)
-		x.PlainSchema = *(*string)(unsafe.Pointer(&__PlainSchemaStringCopy))
-	}
-	x.Length = viewer.Length()
-	x.Format = TypeFormat(viewer.Format())
-	x.Model = TypeModel(viewer.Model())
-}
-
 type EnumFieldData struct {
 	Name  string
 	Value string
@@ -381,14 +430,14 @@ func (x *EnumFieldData) WriteAsRoot(writer *karmem.Writer) (offset uint, err err
 
 func (x *EnumFieldData) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(48)
+	size := uint(28)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(40))
+	writer.Write4At(offset, uint32(28))
 	__NameSize := uint(1 * len(x.Name))
 	__NameOffset, err := writer.Alloc(__NameSize)
 	if err != nil {
@@ -396,7 +445,6 @@ func (x *EnumFieldData) Write(writer *karmem.Writer, start uint) (offset uint, e
 	}
 	writer.Write4At(offset+4, uint32(__NameOffset))
 	writer.Write4At(offset+4+4, uint32(__NameSize))
-	writer.Write4At(offset+4+4+4, 1)
 	__NameSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Name)), __NameSize, __NameSize}
 	writer.WriteAt(__NameOffset, *(*[]byte)(unsafe.Pointer(&__NameSlice)))
 	__ValueSize := uint(1 * len(x.Value))
@@ -404,24 +452,22 @@ func (x *EnumFieldData) Write(writer *karmem.Writer, start uint) (offset uint, e
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+16, uint32(__ValueOffset))
-	writer.Write4At(offset+16+4, uint32(__ValueSize))
-	writer.Write4At(offset+16+4+4, 1)
+	writer.Write4At(offset+12, uint32(__ValueOffset))
+	writer.Write4At(offset+12+4, uint32(__ValueSize))
 	__ValueSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Value)), __ValueSize, __ValueSize}
 	writer.WriteAt(__ValueOffset, *(*[]byte)(unsafe.Pointer(&__ValueSlice)))
-	__TagsSize := uint(32 * len(x.Tags))
+	__TagsSize := uint(16 * len(x.Tags))
 	__TagsOffset, err := writer.Alloc(__TagsSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+28, uint32(__TagsOffset))
-	writer.Write4At(offset+28+4, uint32(__TagsSize))
-	writer.Write4At(offset+28+4+4, 32)
+	writer.Write4At(offset+20, uint32(__TagsOffset))
+	writer.Write4At(offset+20+4, uint32(__TagsSize))
 	for i := range x.Tags {
 		if _, err := x.Tags[i].Write(writer, __TagsOffset); err != nil {
 			return offset, err
 		}
-		__TagsOffset += 32
+		__TagsOffset += 16
 	}
 
 	return offset, nil
@@ -480,14 +526,14 @@ func (x *EnumField) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) 
 
 func (x *EnumField) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(8)
+	size := uint(4)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	__DataSize := uint(48)
+	__DataSize := uint(28)
 	__DataOffset, err := writer.Alloc(__DataSize)
 	if err != nil {
 		return 0, err
@@ -534,14 +580,14 @@ func (x *EnumData) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
 
 func (x *EnumData) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(48)
+	size := uint(33)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(45))
+	writer.Write4At(offset, uint32(33))
 	__NameSize := uint(1 * len(x.Name))
 	__NameOffset, err := writer.Alloc(__NameSize)
 	if err != nil {
@@ -549,47 +595,44 @@ func (x *EnumData) Write(writer *karmem.Writer, start uint) (offset uint, err er
 	}
 	writer.Write4At(offset+4, uint32(__NameOffset))
 	writer.Write4At(offset+4+4, uint32(__NameSize))
-	writer.Write4At(offset+4+4+4, 1)
 	__NameSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Name)), __NameSize, __NameSize}
 	writer.WriteAt(__NameOffset, *(*[]byte)(unsafe.Pointer(&__NameSlice)))
-	__TypeSize := uint(40)
+	__TypeSize := uint(26)
 	__TypeOffset, err := writer.Alloc(__TypeSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+16, uint32(__TypeOffset))
+	writer.Write4At(offset+12, uint32(__TypeOffset))
 	if _, err := x.Type.Write(writer, __TypeOffset); err != nil {
 		return offset, err
 	}
-	__FieldsSize := uint(8 * len(x.Fields))
+	__FieldsSize := uint(4 * len(x.Fields))
 	__FieldsOffset, err := writer.Alloc(__FieldsSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+20, uint32(__FieldsOffset))
-	writer.Write4At(offset+20+4, uint32(__FieldsSize))
-	writer.Write4At(offset+20+4+4, 8)
+	writer.Write4At(offset+16, uint32(__FieldsOffset))
+	writer.Write4At(offset+16+4, uint32(__FieldsSize))
 	for i := range x.Fields {
 		if _, err := x.Fields[i].Write(writer, __FieldsOffset); err != nil {
 			return offset, err
 		}
-		__FieldsOffset += 8
+		__FieldsOffset += 4
 	}
-	__TagsSize := uint(32 * len(x.Tags))
+	__TagsSize := uint(16 * len(x.Tags))
 	__TagsOffset, err := writer.Alloc(__TagsSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+32, uint32(__TagsOffset))
-	writer.Write4At(offset+32+4, uint32(__TagsSize))
-	writer.Write4At(offset+32+4+4, 32)
+	writer.Write4At(offset+24, uint32(__TagsOffset))
+	writer.Write4At(offset+24+4, uint32(__TagsSize))
 	for i := range x.Tags {
 		if _, err := x.Tags[i].Write(writer, __TagsOffset); err != nil {
 			return offset, err
 		}
-		__TagsOffset += 32
+		__TagsOffset += 16
 	}
-	__IsSequentialOffset := offset + 44
+	__IsSequentialOffset := offset + 32
 	writer.Write1At(__IsSequentialOffset, *(*uint8)(unsafe.Pointer(&x.IsSequential)))
 
 	return offset, nil
@@ -656,14 +699,14 @@ func (x *Enumeration) WriteAsRoot(writer *karmem.Writer) (offset uint, err error
 
 func (x *Enumeration) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(8)
+	size := uint(4)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	__DataSize := uint(48)
+	__DataSize := uint(33)
 	__DataOffset, err := writer.Alloc(__DataSize)
 	if err != nil {
 		return 0, err
@@ -710,14 +753,14 @@ func (x *StructFieldData) WriteAsRoot(writer *karmem.Writer) (offset uint, err e
 
 func (x *StructFieldData) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(48)
+	size := uint(32)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(40))
+	writer.Write4At(offset, uint32(32))
 	__NameSize := uint(1 * len(x.Name))
 	__NameOffset, err := writer.Alloc(__NameSize)
 	if err != nil {
@@ -725,40 +768,38 @@ func (x *StructFieldData) Write(writer *karmem.Writer, start uint) (offset uint,
 	}
 	writer.Write4At(offset+4, uint32(__NameOffset))
 	writer.Write4At(offset+4+4, uint32(__NameSize))
-	writer.Write4At(offset+4+4+4, 1)
 	__NameSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Name)), __NameSize, __NameSize}
 	writer.WriteAt(__NameOffset, *(*[]byte)(unsafe.Pointer(&__NameSlice)))
-	__TypeSize := uint(40)
+	__TypeSize := uint(26)
 	__TypeOffset, err := writer.Alloc(__TypeSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+16, uint32(__TypeOffset))
+	writer.Write4At(offset+12, uint32(__TypeOffset))
 	if _, err := x.Type.Write(writer, __TypeOffset); err != nil {
 		return offset, err
 	}
-	__OffsetOffset := offset + 20
+	__OffsetOffset := offset + 16
 	writer.Write4At(__OffsetOffset, *(*uint32)(unsafe.Pointer(&x.Offset)))
-	__TagsSize := uint(32 * len(x.Tags))
+	__TagsSize := uint(16 * len(x.Tags))
 	__TagsOffset, err := writer.Alloc(__TagsSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+24, uint32(__TagsOffset))
-	writer.Write4At(offset+24+4, uint32(__TagsSize))
-	writer.Write4At(offset+24+4+4, 32)
+	writer.Write4At(offset+20, uint32(__TagsOffset))
+	writer.Write4At(offset+20+4, uint32(__TagsSize))
 	for i := range x.Tags {
 		if _, err := x.Tags[i].Write(writer, __TagsOffset); err != nil {
 			return offset, err
 		}
-		__TagsOffset += 32
+		__TagsOffset += 16
 	}
-	__SizeSize := uint(24)
+	__SizeSize := uint(16)
 	__SizeOffset, err := writer.Alloc(__SizeSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+36, uint32(__SizeOffset))
+	writer.Write4At(offset+28, uint32(__SizeOffset))
 	if _, err := x.Size.Write(writer, __SizeOffset); err != nil {
 		return offset, err
 	}
@@ -816,14 +857,14 @@ func (x *StructField) WriteAsRoot(writer *karmem.Writer) (offset uint, err error
 
 func (x *StructField) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(8)
+	size := uint(4)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	__DataSize := uint(48)
+	__DataSize := uint(32)
 	__DataOffset, err := writer.Alloc(__DataSize)
 	if err != nil {
 		return 0, err
@@ -851,6 +892,7 @@ type StructData struct {
 	Fields []StructField
 	Class  StructClass
 	Tags   []Tag
+	Packed bool
 }
 
 func NewStructData() StructData {
@@ -871,14 +913,14 @@ func (x *StructData) WriteAsRoot(writer *karmem.Writer) (offset uint, err error)
 
 func (x *StructData) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(56)
+	size := uint(42)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(53))
+	writer.Write4At(offset, uint32(42))
 	__IDOffset := offset + 4
 	writer.Write8At(__IDOffset, *(*uint64)(unsafe.Pointer(&x.ID)))
 	__NameSize := uint(1 * len(x.Name))
@@ -888,48 +930,47 @@ func (x *StructData) Write(writer *karmem.Writer, start uint) (offset uint, err 
 	}
 	writer.Write4At(offset+12, uint32(__NameOffset))
 	writer.Write4At(offset+12+4, uint32(__NameSize))
-	writer.Write4At(offset+12+4+4, 1)
 	__NameSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Name)), __NameSize, __NameSize}
 	writer.WriteAt(__NameOffset, *(*[]byte)(unsafe.Pointer(&__NameSlice)))
-	__SizeSize := uint(40)
+	__SizeSize := uint(28)
 	__SizeOffset, err := writer.Alloc(__SizeSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+24, uint32(__SizeOffset))
+	writer.Write4At(offset+20, uint32(__SizeOffset))
 	if _, err := x.Size.Write(writer, __SizeOffset); err != nil {
 		return offset, err
 	}
-	__FieldsSize := uint(8 * len(x.Fields))
+	__FieldsSize := uint(4 * len(x.Fields))
 	__FieldsOffset, err := writer.Alloc(__FieldsSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+28, uint32(__FieldsOffset))
-	writer.Write4At(offset+28+4, uint32(__FieldsSize))
-	writer.Write4At(offset+28+4+4, 8)
+	writer.Write4At(offset+24, uint32(__FieldsOffset))
+	writer.Write4At(offset+24+4, uint32(__FieldsSize))
 	for i := range x.Fields {
 		if _, err := x.Fields[i].Write(writer, __FieldsOffset); err != nil {
 			return offset, err
 		}
-		__FieldsOffset += 8
+		__FieldsOffset += 4
 	}
-	__ClassOffset := offset + 40
+	__ClassOffset := offset + 32
 	writer.Write1At(__ClassOffset, *(*uint8)(unsafe.Pointer(&x.Class)))
-	__TagsSize := uint(32 * len(x.Tags))
+	__TagsSize := uint(16 * len(x.Tags))
 	__TagsOffset, err := writer.Alloc(__TagsSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+41, uint32(__TagsOffset))
-	writer.Write4At(offset+41+4, uint32(__TagsSize))
-	writer.Write4At(offset+41+4+4, 32)
+	writer.Write4At(offset+33, uint32(__TagsOffset))
+	writer.Write4At(offset+33+4, uint32(__TagsSize))
 	for i := range x.Tags {
 		if _, err := x.Tags[i].Write(writer, __TagsOffset); err != nil {
 			return offset, err
 		}
-		__TagsOffset += 32
+		__TagsOffset += 16
 	}
+	__PackedOffset := offset + 41
+	writer.Write1At(__PackedOffset, *(*uint8)(unsafe.Pointer(&x.Packed)))
 
 	return offset, nil
 }
@@ -972,6 +1013,7 @@ func (x *StructData) Read(viewer *StructDataViewer, reader *karmem.Reader) {
 		x.Tags[i].Read(&__TagsSlice[i], reader)
 	}
 	x.Tags = x.Tags[:__TagsLen]
+	x.Packed = viewer.Packed()
 }
 
 type Structure struct {
@@ -996,14 +1038,14 @@ func (x *Structure) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) 
 
 func (x *Structure) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(8)
+	size := uint(4)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	__DataSize := uint(56)
+	__DataSize := uint(42)
 	__DataOffset, err := writer.Alloc(__DataSize)
 	if err != nil {
 		return 0, err
@@ -1046,7 +1088,7 @@ func (x *ContentSize) WriteAsRoot(writer *karmem.Writer) (offset uint, err error
 
 func (x *ContentSize) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(16)
+	size := uint(8)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
@@ -1092,14 +1134,14 @@ func (x *ContentOptions) WriteAsRoot(writer *karmem.Writer) (offset uint, err er
 
 func (x *ContentOptions) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(48)
+	size := uint(28)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(40))
+	writer.Write4At(offset, uint32(28))
 	__ModuleSize := uint(1 * len(x.Module))
 	__ModuleOffset, err := writer.Alloc(__ModuleSize)
 	if err != nil {
@@ -1107,7 +1149,6 @@ func (x *ContentOptions) Write(writer *karmem.Writer, start uint) (offset uint, 
 	}
 	writer.Write4At(offset+4, uint32(__ModuleOffset))
 	writer.Write4At(offset+4+4, uint32(__ModuleSize))
-	writer.Write4At(offset+4+4+4, 1)
 	__ModuleSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Module)), __ModuleSize, __ModuleSize}
 	writer.WriteAt(__ModuleOffset, *(*[]byte)(unsafe.Pointer(&__ModuleSlice)))
 	__ImportSize := uint(1 * len(x.Import))
@@ -1115,9 +1156,8 @@ func (x *ContentOptions) Write(writer *karmem.Writer, start uint) (offset uint, 
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+16, uint32(__ImportOffset))
-	writer.Write4At(offset+16+4, uint32(__ImportSize))
-	writer.Write4At(offset+16+4+4, 1)
+	writer.Write4At(offset+12, uint32(__ImportOffset))
+	writer.Write4At(offset+12+4, uint32(__ImportSize))
 	__ImportSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Import)), __ImportSize, __ImportSize}
 	writer.WriteAt(__ImportOffset, *(*[]byte)(unsafe.Pointer(&__ImportSlice)))
 	__PrefixSize := uint(1 * len(x.Prefix))
@@ -1125,9 +1165,8 @@ func (x *ContentOptions) Write(writer *karmem.Writer, start uint) (offset uint, 
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+28, uint32(__PrefixOffset))
-	writer.Write4At(offset+28+4, uint32(__PrefixSize))
-	writer.Write4At(offset+28+4+4, 1)
+	writer.Write4At(offset+20, uint32(__PrefixOffset))
+	writer.Write4At(offset+20+4, uint32(__PrefixSize))
 	__PrefixSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Prefix)), __PrefixSize, __PrefixSize}
 	writer.WriteAt(__PrefixOffset, *(*[]byte)(unsafe.Pointer(&__PrefixSlice)))
 
@@ -1165,6 +1204,7 @@ type Content struct {
 	Enums   []Enumeration
 	Size    ContentSize
 	Name    string
+	Packed  bool
 }
 
 func NewContent() Content {
@@ -1185,62 +1225,59 @@ func (x *Content) WriteAsRoot(writer *karmem.Writer) (offset uint, err error) {
 
 func (x *Content) Write(writer *karmem.Writer, start uint) (offset uint, err error) {
 	offset = start
-	size := uint(64)
+	size := uint(41)
 	if offset == 0 {
 		offset, err = writer.Alloc(size)
 		if err != nil {
 			return 0, err
 		}
 	}
-	writer.Write4At(offset, uint32(56))
-	__TagsSize := uint(32 * len(x.Tags))
+	writer.Write4At(offset, uint32(41))
+	__TagsSize := uint(16 * len(x.Tags))
 	__TagsOffset, err := writer.Alloc(__TagsSize)
 	if err != nil {
 		return 0, err
 	}
 	writer.Write4At(offset+4, uint32(__TagsOffset))
 	writer.Write4At(offset+4+4, uint32(__TagsSize))
-	writer.Write4At(offset+4+4+4, 32)
 	for i := range x.Tags {
 		if _, err := x.Tags[i].Write(writer, __TagsOffset); err != nil {
 			return offset, err
 		}
-		__TagsOffset += 32
+		__TagsOffset += 16
 	}
-	__StructsSize := uint(8 * len(x.Structs))
+	__StructsSize := uint(4 * len(x.Structs))
 	__StructsOffset, err := writer.Alloc(__StructsSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+16, uint32(__StructsOffset))
-	writer.Write4At(offset+16+4, uint32(__StructsSize))
-	writer.Write4At(offset+16+4+4, 8)
+	writer.Write4At(offset+12, uint32(__StructsOffset))
+	writer.Write4At(offset+12+4, uint32(__StructsSize))
 	for i := range x.Structs {
 		if _, err := x.Structs[i].Write(writer, __StructsOffset); err != nil {
 			return offset, err
 		}
-		__StructsOffset += 8
+		__StructsOffset += 4
 	}
-	__EnumsSize := uint(8 * len(x.Enums))
+	__EnumsSize := uint(4 * len(x.Enums))
 	__EnumsOffset, err := writer.Alloc(__EnumsSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+28, uint32(__EnumsOffset))
-	writer.Write4At(offset+28+4, uint32(__EnumsSize))
-	writer.Write4At(offset+28+4+4, 8)
+	writer.Write4At(offset+20, uint32(__EnumsOffset))
+	writer.Write4At(offset+20+4, uint32(__EnumsSize))
 	for i := range x.Enums {
 		if _, err := x.Enums[i].Write(writer, __EnumsOffset); err != nil {
 			return offset, err
 		}
-		__EnumsOffset += 8
+		__EnumsOffset += 4
 	}
-	__SizeSize := uint(16)
+	__SizeSize := uint(8)
 	__SizeOffset, err := writer.Alloc(__SizeSize)
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+40, uint32(__SizeOffset))
+	writer.Write4At(offset+28, uint32(__SizeOffset))
 	if _, err := x.Size.Write(writer, __SizeOffset); err != nil {
 		return offset, err
 	}
@@ -1249,11 +1286,12 @@ func (x *Content) Write(writer *karmem.Writer, start uint) (offset uint, err err
 	if err != nil {
 		return 0, err
 	}
-	writer.Write4At(offset+44, uint32(__NameOffset))
-	writer.Write4At(offset+44+4, uint32(__NameSize))
-	writer.Write4At(offset+44+4+4, 1)
+	writer.Write4At(offset+32, uint32(__NameOffset))
+	writer.Write4At(offset+32+4, uint32(__NameSize))
 	__NameSlice := [3]uint{*(*uint)(unsafe.Pointer(&x.Name)), __NameSize, __NameSize}
 	writer.WriteAt(__NameOffset, *(*[]byte)(unsafe.Pointer(&__NameSlice)))
+	__PackedOffset := offset + 40
+	writer.Write1At(__PackedOffset, *(*uint8)(unsafe.Pointer(&x.Packed)))
 
 	return offset, nil
 }
@@ -1306,149 +1344,13 @@ func (x *Content) Read(viewer *ContentViewer, reader *karmem.Reader) {
 		copy(__NameStringCopy, __NameString)
 		x.Name = *(*string)(unsafe.Pointer(&__NameStringCopy))
 	}
+	x.Packed = viewer.Packed()
 }
 
-type TagViewer struct {
-	_data [32]byte
-}
-
-func NewTagViewer(reader *karmem.Reader, offset uint32) (v *TagViewer) {
-	if !reader.IsValidOffset(offset, 32) {
-		return (*TagViewer)(unsafe.Pointer(&_Null))
-	}
-	v = (*TagViewer)(unsafe.Add(reader.Pointer, offset))
-	return v
-}
-
-func (x *TagViewer) size() uint32 {
-	return 32
-}
-func (x *TagViewer) Name(reader *karmem.Reader) (v string) {
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 0))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 0+4))
-	if !reader.IsValidOffset(offset, size) {
-		return ""
-	}
-	length := uintptr(size / 1)
-	slice := [3]uintptr{
-		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
-	}
-	return *(*string)(unsafe.Pointer(&slice))
-}
-func (x *TagViewer) Value(reader *karmem.Reader) (v string) {
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 12))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 12+4))
-	if !reader.IsValidOffset(offset, size) {
-		return ""
-	}
-	length := uintptr(size / 1)
-	slice := [3]uintptr{
-		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
-	}
-	return *(*string)(unsafe.Pointer(&slice))
-}
-
-type StructSizeViewer struct {
-	_data [40]byte
-}
-
-func NewStructSizeViewer(reader *karmem.Reader, offset uint32) (v *StructSizeViewer) {
-	if !reader.IsValidOffset(offset, 8) {
-		return (*StructSizeViewer)(unsafe.Pointer(&_Null))
-	}
-	v = (*StructSizeViewer)(unsafe.Add(reader.Pointer, offset))
-	if !reader.IsValidOffset(offset, v.size()) {
-		return (*StructSizeViewer)(unsafe.Pointer(&_Null))
-	}
-	return v
-}
-
-func (x *StructSizeViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
-}
-func (x *StructSizeViewer) Minimum() (v uint32) {
-	if 4+4 > x.size() {
-		return v
-	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
-}
-func (x *StructSizeViewer) Content() (v uint32) {
-	if 8+4 > x.size() {
-		return v
-	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 8))
-}
-func (x *StructSizeViewer) Padding() (v uint32) {
-	if 12+4 > x.size() {
-		return v
-	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 12))
-}
-func (x *StructSizeViewer) Total() (v uint32) {
-	if 16+4 > x.size() {
-		return v
-	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16))
-}
-func (x *StructSizeViewer) TotalGroup(reader *karmem.Reader) (v []uint8) {
-	if 20+12 > x.size() {
-		return []uint8{}
-	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 20))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 20+4))
-	if !reader.IsValidOffset(offset, size) {
-		return []uint8{}
-	}
-	length := uintptr(size / 1)
-	slice := [3]uintptr{
-		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
-	}
-	return *(*[]uint8)(unsafe.Pointer(&slice))
-}
-
-type StructFieldSizeViewer struct {
-	_data [24]byte
-}
-
-func NewStructFieldSizeViewer(reader *karmem.Reader, offset uint32) (v *StructFieldSizeViewer) {
-	if !reader.IsValidOffset(offset, 8) {
-		return (*StructFieldSizeViewer)(unsafe.Pointer(&_Null))
-	}
-	v = (*StructFieldSizeViewer)(unsafe.Add(reader.Pointer, offset))
-	if !reader.IsValidOffset(offset, v.size()) {
-		return (*StructFieldSizeViewer)(unsafe.Pointer(&_Null))
-	}
-	return v
-}
-
-func (x *StructFieldSizeViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
-}
-func (x *StructFieldSizeViewer) Minimum() (v uint32) {
-	if 4+4 > x.size() {
-		return v
-	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
-}
-func (x *StructFieldSizeViewer) Allocation() (v uint32) {
-	if 8+4 > x.size() {
-		return v
-	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 8))
-}
-func (x *StructFieldSizeViewer) Field() (v uint32) {
-	if 12+4 > x.size() {
-		return v
-	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 12))
-}
-
-type TypeViewer struct {
-	_data [40]byte
-}
+type TypeViewer [26]byte
 
 func NewTypeViewer(reader *karmem.Reader, offset uint32) (v *TypeViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*TypeViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*TypeViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1459,14 +1361,14 @@ func NewTypeViewer(reader *karmem.Reader, offset uint32) (v *TypeViewer) {
 }
 
 func (x *TypeViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *TypeViewer) Schema(reader *karmem.Reader) (v string) {
-	if 4+12 > x.size() {
+	if 4+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1477,11 +1379,11 @@ func (x *TypeViewer) Schema(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *TypeViewer) PlainSchema(reader *karmem.Reader) (v string) {
-	if 16+12 > x.size() {
+	if 12+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1492,30 +1394,175 @@ func (x *TypeViewer) PlainSchema(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *TypeViewer) Length() (v uint32) {
-	if 28+4 > x.size() {
+	if 20+4 > x.size() {
 		return v
 	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 28))
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20))
 }
 func (x *TypeViewer) Format() (v TypeFormat) {
-	if 32+1 > x.size() {
+	if 24+1 > x.size() {
 		return v
 	}
-	return *(*TypeFormat)(unsafe.Add(unsafe.Pointer(&x._data), 32))
+	return *(*TypeFormat)(unsafe.Add(unsafe.Pointer(x), 24))
 }
 func (x *TypeViewer) Model() (v TypeModel) {
-	if 33+1 > x.size() {
+	if 25+1 > x.size() {
 		return v
 	}
-	return *(*TypeModel)(unsafe.Add(unsafe.Pointer(&x._data), 33))
+	return *(*TypeModel)(unsafe.Add(unsafe.Pointer(x), 25))
 }
 
-type EnumFieldDataViewer struct {
-	_data [48]byte
+type PaddingTypeViewer [4]byte
+
+func NewPaddingTypeViewer(reader *karmem.Reader, offset uint32) (v *PaddingTypeViewer) {
+	if !reader.IsValidOffset(offset, 4) {
+		return (*PaddingTypeViewer)(unsafe.Pointer(&_Null))
+	}
+	v = (*PaddingTypeViewer)(unsafe.Add(reader.Pointer, offset))
+	return v
 }
+
+func (x *PaddingTypeViewer) size() uint32 {
+	return 4
+}
+func (x *PaddingTypeViewer) Data(reader *karmem.Reader) (v *TypeViewer) {
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 0))
+	return NewTypeViewer(reader, offset)
+}
+
+type TagViewer [16]byte
+
+func NewTagViewer(reader *karmem.Reader, offset uint32) (v *TagViewer) {
+	if !reader.IsValidOffset(offset, 16) {
+		return (*TagViewer)(unsafe.Pointer(&_Null))
+	}
+	v = (*TagViewer)(unsafe.Add(reader.Pointer, offset))
+	return v
+}
+
+func (x *TagViewer) size() uint32 {
+	return 16
+}
+func (x *TagViewer) Name(reader *karmem.Reader) (v string) {
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 0))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 0+4))
+	if !reader.IsValidOffset(offset, size) {
+		return ""
+	}
+	length := uintptr(size / 1)
+	slice := [3]uintptr{
+		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
+	}
+	return *(*string)(unsafe.Pointer(&slice))
+}
+func (x *TagViewer) Value(reader *karmem.Reader) (v string) {
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 8))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 8+4))
+	if !reader.IsValidOffset(offset, size) {
+		return ""
+	}
+	length := uintptr(size / 1)
+	slice := [3]uintptr{
+		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
+	}
+	return *(*string)(unsafe.Pointer(&slice))
+}
+
+type StructSizeViewer [28]byte
+
+func NewStructSizeViewer(reader *karmem.Reader, offset uint32) (v *StructSizeViewer) {
+	if !reader.IsValidOffset(offset, 4) {
+		return (*StructSizeViewer)(unsafe.Pointer(&_Null))
+	}
+	v = (*StructSizeViewer)(unsafe.Add(reader.Pointer, offset))
+	if !reader.IsValidOffset(offset, v.size()) {
+		return (*StructSizeViewer)(unsafe.Pointer(&_Null))
+	}
+	return v
+}
+
+func (x *StructSizeViewer) size() uint32 {
+	return *(*uint32)(unsafe.Pointer(x))
+}
+func (x *StructSizeViewer) Minimum() (v uint32) {
+	if 4+4 > x.size() {
+		return v
+	}
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
+}
+func (x *StructSizeViewer) Content() (v uint32) {
+	if 8+4 > x.size() {
+		return v
+	}
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 8))
+}
+func (x *StructSizeViewer) Padding() (v uint32) {
+	if 12+4 > x.size() {
+		return v
+	}
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12))
+}
+func (x *StructSizeViewer) Total() (v uint32) {
+	if 16+4 > x.size() {
+		return v
+	}
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 16))
+}
+func (x *StructSizeViewer) TotalGroup(reader *karmem.Reader) (v []PaddingTypeViewer) {
+	if 20+8 > x.size() {
+		return []PaddingTypeViewer{}
+	}
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20+4))
+	if !reader.IsValidOffset(offset, size) {
+		return []PaddingTypeViewer{}
+	}
+	length := uintptr(size / 4)
+	slice := [3]uintptr{
+		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
+	}
+	return *(*[]PaddingTypeViewer)(unsafe.Pointer(&slice))
+}
+
+type StructFieldSizeViewer [16]byte
+
+func NewStructFieldSizeViewer(reader *karmem.Reader, offset uint32) (v *StructFieldSizeViewer) {
+	if !reader.IsValidOffset(offset, 4) {
+		return (*StructFieldSizeViewer)(unsafe.Pointer(&_Null))
+	}
+	v = (*StructFieldSizeViewer)(unsafe.Add(reader.Pointer, offset))
+	if !reader.IsValidOffset(offset, v.size()) {
+		return (*StructFieldSizeViewer)(unsafe.Pointer(&_Null))
+	}
+	return v
+}
+
+func (x *StructFieldSizeViewer) size() uint32 {
+	return *(*uint32)(unsafe.Pointer(x))
+}
+func (x *StructFieldSizeViewer) Minimum() (v uint32) {
+	if 4+4 > x.size() {
+		return v
+	}
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
+}
+func (x *StructFieldSizeViewer) Allocation() (v uint32) {
+	if 8+4 > x.size() {
+		return v
+	}
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 8))
+}
+func (x *StructFieldSizeViewer) Field() (v uint32) {
+	if 12+4 > x.size() {
+		return v
+	}
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12))
+}
+
+type EnumFieldDataViewer [28]byte
 
 func NewEnumFieldDataViewer(reader *karmem.Reader, offset uint32) (v *EnumFieldDataViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*EnumFieldDataViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*EnumFieldDataViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1526,14 +1573,14 @@ func NewEnumFieldDataViewer(reader *karmem.Reader, offset uint32) (v *EnumFieldD
 }
 
 func (x *EnumFieldDataViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *EnumFieldDataViewer) Name(reader *karmem.Reader) (v string) {
-	if 4+12 > x.size() {
+	if 4+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1544,11 +1591,11 @@ func (x *EnumFieldDataViewer) Name(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *EnumFieldDataViewer) Value(reader *karmem.Reader) (v string) {
-	if 16+12 > x.size() {
+	if 12+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1559,27 +1606,25 @@ func (x *EnumFieldDataViewer) Value(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *EnumFieldDataViewer) Tags(reader *karmem.Reader) (v []TagViewer) {
-	if 28+12 > x.size() {
+	if 20+8 > x.size() {
 		return []TagViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 28))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 28+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []TagViewer{}
 	}
-	length := uintptr(size / 32)
+	length := uintptr(size / 16)
 	slice := [3]uintptr{
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*[]TagViewer)(unsafe.Pointer(&slice))
 }
 
-type EnumFieldViewer struct {
-	_data [8]byte
-}
+type EnumFieldViewer [4]byte
 
 func NewEnumFieldViewer(reader *karmem.Reader, offset uint32) (v *EnumFieldViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*EnumFieldViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*EnumFieldViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1587,19 +1632,17 @@ func NewEnumFieldViewer(reader *karmem.Reader, offset uint32) (v *EnumFieldViewe
 }
 
 func (x *EnumFieldViewer) size() uint32 {
-	return 8
+	return 4
 }
 func (x *EnumFieldViewer) Data(reader *karmem.Reader) (v *EnumFieldDataViewer) {
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 0))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 0))
 	return NewEnumFieldDataViewer(reader, offset)
 }
 
-type EnumDataViewer struct {
-	_data [48]byte
-}
+type EnumDataViewer [33]byte
 
 func NewEnumDataViewer(reader *karmem.Reader, offset uint32) (v *EnumDataViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*EnumDataViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*EnumDataViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1610,14 +1653,14 @@ func NewEnumDataViewer(reader *karmem.Reader, offset uint32) (v *EnumDataViewer)
 }
 
 func (x *EnumDataViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *EnumDataViewer) Name(reader *karmem.Reader) (v string) {
-	if 4+12 > x.size() {
+	if 4+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1628,55 +1671,53 @@ func (x *EnumDataViewer) Name(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *EnumDataViewer) Type(reader *karmem.Reader) (v *TypeViewer) {
-	if 16+4 > x.size() {
+	if 12+4 > x.size() {
 		return (*TypeViewer)(unsafe.Pointer(&_Null))
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12))
 	return NewTypeViewer(reader, offset)
 }
 func (x *EnumDataViewer) Fields(reader *karmem.Reader) (v []EnumFieldViewer) {
-	if 20+12 > x.size() {
+	if 16+8 > x.size() {
 		return []EnumFieldViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 20))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 20+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 16))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 16+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []EnumFieldViewer{}
 	}
-	length := uintptr(size / 8)
+	length := uintptr(size / 4)
 	slice := [3]uintptr{
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*[]EnumFieldViewer)(unsafe.Pointer(&slice))
 }
 func (x *EnumDataViewer) Tags(reader *karmem.Reader) (v []TagViewer) {
-	if 32+12 > x.size() {
+	if 24+8 > x.size() {
 		return []TagViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 32))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 32+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 24))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 24+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []TagViewer{}
 	}
-	length := uintptr(size / 32)
+	length := uintptr(size / 16)
 	slice := [3]uintptr{
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*[]TagViewer)(unsafe.Pointer(&slice))
 }
 func (x *EnumDataViewer) IsSequential() (v bool) {
-	if 44+1 > x.size() {
+	if 32+1 > x.size() {
 		return v
 	}
-	return *(*bool)(unsafe.Add(unsafe.Pointer(&x._data), 44))
+	return *(*bool)(unsafe.Add(unsafe.Pointer(x), 32))
 }
 
-type EnumerationViewer struct {
-	_data [8]byte
-}
+type EnumerationViewer [4]byte
 
 func NewEnumerationViewer(reader *karmem.Reader, offset uint32) (v *EnumerationViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*EnumerationViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*EnumerationViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1684,19 +1725,17 @@ func NewEnumerationViewer(reader *karmem.Reader, offset uint32) (v *EnumerationV
 }
 
 func (x *EnumerationViewer) size() uint32 {
-	return 8
+	return 4
 }
 func (x *EnumerationViewer) Data(reader *karmem.Reader) (v *EnumDataViewer) {
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 0))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 0))
 	return NewEnumDataViewer(reader, offset)
 }
 
-type StructFieldDataViewer struct {
-	_data [48]byte
-}
+type StructFieldDataViewer [32]byte
 
 func NewStructFieldDataViewer(reader *karmem.Reader, offset uint32) (v *StructFieldDataViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*StructFieldDataViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*StructFieldDataViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1707,14 +1746,14 @@ func NewStructFieldDataViewer(reader *karmem.Reader, offset uint32) (v *StructFi
 }
 
 func (x *StructFieldDataViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *StructFieldDataViewer) Name(reader *karmem.Reader) (v string) {
-	if 4+12 > x.size() {
+	if 4+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1725,47 +1764,45 @@ func (x *StructFieldDataViewer) Name(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *StructFieldDataViewer) Type(reader *karmem.Reader) (v *TypeViewer) {
-	if 16+4 > x.size() {
+	if 12+4 > x.size() {
 		return (*TypeViewer)(unsafe.Pointer(&_Null))
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12))
 	return NewTypeViewer(reader, offset)
 }
 func (x *StructFieldDataViewer) Offset() (v uint32) {
-	if 20+4 > x.size() {
+	if 16+4 > x.size() {
 		return v
 	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 20))
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 16))
 }
 func (x *StructFieldDataViewer) Tags(reader *karmem.Reader) (v []TagViewer) {
-	if 24+12 > x.size() {
+	if 20+8 > x.size() {
 		return []TagViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 24))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 24+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []TagViewer{}
 	}
-	length := uintptr(size / 32)
+	length := uintptr(size / 16)
 	slice := [3]uintptr{
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*[]TagViewer)(unsafe.Pointer(&slice))
 }
 func (x *StructFieldDataViewer) Size(reader *karmem.Reader) (v *StructFieldSizeViewer) {
-	if 36+4 > x.size() {
+	if 28+4 > x.size() {
 		return (*StructFieldSizeViewer)(unsafe.Pointer(&_Null))
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 36))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 28))
 	return NewStructFieldSizeViewer(reader, offset)
 }
 
-type StructFieldViewer struct {
-	_data [8]byte
-}
+type StructFieldViewer [4]byte
 
 func NewStructFieldViewer(reader *karmem.Reader, offset uint32) (v *StructFieldViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*StructFieldViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*StructFieldViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1773,19 +1810,17 @@ func NewStructFieldViewer(reader *karmem.Reader, offset uint32) (v *StructFieldV
 }
 
 func (x *StructFieldViewer) size() uint32 {
-	return 8
+	return 4
 }
 func (x *StructFieldViewer) Data(reader *karmem.Reader) (v *StructFieldDataViewer) {
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 0))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 0))
 	return NewStructFieldDataViewer(reader, offset)
 }
 
-type StructDataViewer struct {
-	_data [56]byte
-}
+type StructDataViewer [42]byte
 
 func NewStructDataViewer(reader *karmem.Reader, offset uint32) (v *StructDataViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*StructDataViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*StructDataViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1796,20 +1831,20 @@ func NewStructDataViewer(reader *karmem.Reader, offset uint32) (v *StructDataVie
 }
 
 func (x *StructDataViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *StructDataViewer) ID() (v uint64) {
 	if 4+8 > x.size() {
 		return v
 	}
-	return *(*uint64)(unsafe.Add(unsafe.Pointer(&x._data), 4))
+	return *(*uint64)(unsafe.Add(unsafe.Pointer(x), 4))
 }
 func (x *StructDataViewer) Name(reader *karmem.Reader) (v string) {
-	if 12+12 > x.size() {
+	if 12+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 12))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 12+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1820,55 +1855,59 @@ func (x *StructDataViewer) Name(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *StructDataViewer) Size(reader *karmem.Reader) (v *StructSizeViewer) {
-	if 24+4 > x.size() {
+	if 20+4 > x.size() {
 		return (*StructSizeViewer)(unsafe.Pointer(&_Null))
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 24))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20))
 	return NewStructSizeViewer(reader, offset)
 }
 func (x *StructDataViewer) Fields(reader *karmem.Reader) (v []StructFieldViewer) {
-	if 28+12 > x.size() {
+	if 24+8 > x.size() {
 		return []StructFieldViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 28))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 28+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 24))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 24+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []StructFieldViewer{}
 	}
-	length := uintptr(size / 8)
+	length := uintptr(size / 4)
 	slice := [3]uintptr{
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*[]StructFieldViewer)(unsafe.Pointer(&slice))
 }
 func (x *StructDataViewer) Class() (v StructClass) {
-	if 40+1 > x.size() {
+	if 32+1 > x.size() {
 		return v
 	}
-	return *(*StructClass)(unsafe.Add(unsafe.Pointer(&x._data), 40))
+	return *(*StructClass)(unsafe.Add(unsafe.Pointer(x), 32))
 }
 func (x *StructDataViewer) Tags(reader *karmem.Reader) (v []TagViewer) {
-	if 41+12 > x.size() {
+	if 33+8 > x.size() {
 		return []TagViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 41))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 41+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 33))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 33+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []TagViewer{}
 	}
-	length := uintptr(size / 32)
+	length := uintptr(size / 16)
 	slice := [3]uintptr{
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*[]TagViewer)(unsafe.Pointer(&slice))
 }
-
-type StructureViewer struct {
-	_data [8]byte
+func (x *StructDataViewer) Packed() (v bool) {
+	if 41+1 > x.size() {
+		return v
+	}
+	return *(*bool)(unsafe.Add(unsafe.Pointer(x), 41))
 }
 
+type StructureViewer [4]byte
+
 func NewStructureViewer(reader *karmem.Reader, offset uint32) (v *StructureViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*StructureViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*StructureViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1876,19 +1915,17 @@ func NewStructureViewer(reader *karmem.Reader, offset uint32) (v *StructureViewe
 }
 
 func (x *StructureViewer) size() uint32 {
-	return 8
+	return 4
 }
 func (x *StructureViewer) Data(reader *karmem.Reader) (v *StructDataViewer) {
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 0))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 0))
 	return NewStructDataViewer(reader, offset)
 }
 
-type ContentSizeViewer struct {
-	_data [16]byte
-}
+type ContentSizeViewer [8]byte
 
 func NewContentSizeViewer(reader *karmem.Reader, offset uint32) (v *ContentSizeViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*ContentSizeViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*ContentSizeViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1899,21 +1936,19 @@ func NewContentSizeViewer(reader *karmem.Reader, offset uint32) (v *ContentSizeV
 }
 
 func (x *ContentSizeViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *ContentSizeViewer) Largest() (v uint32) {
 	if 4+4 > x.size() {
 		return v
 	}
-	return *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
+	return *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
 }
 
-type ContentOptionsViewer struct {
-	_data [48]byte
-}
+type ContentOptionsViewer [28]byte
 
 func NewContentOptionsViewer(reader *karmem.Reader, offset uint32) (v *ContentOptionsViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*ContentOptionsViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*ContentOptionsViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1924,14 +1959,14 @@ func NewContentOptionsViewer(reader *karmem.Reader, offset uint32) (v *ContentOp
 }
 
 func (x *ContentOptionsViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *ContentOptionsViewer) Module(reader *karmem.Reader) (v string) {
-	if 4+12 > x.size() {
+	if 4+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1942,11 +1977,11 @@ func (x *ContentOptionsViewer) Module(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *ContentOptionsViewer) Import(reader *karmem.Reader) (v string) {
-	if 16+12 > x.size() {
+	if 12+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1957,11 +1992,11 @@ func (x *ContentOptionsViewer) Import(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 func (x *ContentOptionsViewer) Prefix(reader *karmem.Reader) (v string) {
-	if 28+12 > x.size() {
+	if 20+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 28))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 28+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -1972,12 +2007,10 @@ func (x *ContentOptionsViewer) Prefix(reader *karmem.Reader) (v string) {
 	return *(*string)(unsafe.Pointer(&slice))
 }
 
-type ContentViewer struct {
-	_data [64]byte
-}
+type ContentViewer [41]byte
 
 func NewContentViewer(reader *karmem.Reader, offset uint32) (v *ContentViewer) {
-	if !reader.IsValidOffset(offset, 8) {
+	if !reader.IsValidOffset(offset, 4) {
 		return (*ContentViewer)(unsafe.Pointer(&_Null))
 	}
 	v = (*ContentViewer)(unsafe.Add(reader.Pointer, offset))
@@ -1988,66 +2021,66 @@ func NewContentViewer(reader *karmem.Reader, offset uint32) (v *ContentViewer) {
 }
 
 func (x *ContentViewer) size() uint32 {
-	return *(*uint32)(unsafe.Pointer(&x._data))
+	return *(*uint32)(unsafe.Pointer(x))
 }
 func (x *ContentViewer) Tags(reader *karmem.Reader) (v []TagViewer) {
-	if 4+12 > x.size() {
+	if 4+8 > x.size() {
 		return []TagViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 4+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 4+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []TagViewer{}
 	}
-	length := uintptr(size / 32)
+	length := uintptr(size / 16)
 	slice := [3]uintptr{
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*[]TagViewer)(unsafe.Pointer(&slice))
 }
 func (x *ContentViewer) Structs(reader *karmem.Reader) (v []StructureViewer) {
-	if 16+12 > x.size() {
+	if 12+8 > x.size() {
 		return []StructureViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 16+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 12+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []StructureViewer{}
 	}
-	length := uintptr(size / 8)
+	length := uintptr(size / 4)
 	slice := [3]uintptr{
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*[]StructureViewer)(unsafe.Pointer(&slice))
 }
 func (x *ContentViewer) Enums(reader *karmem.Reader) (v []EnumerationViewer) {
-	if 28+12 > x.size() {
+	if 20+8 > x.size() {
 		return []EnumerationViewer{}
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 28))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 28+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 20+4))
 	if !reader.IsValidOffset(offset, size) {
 		return []EnumerationViewer{}
 	}
-	length := uintptr(size / 8)
+	length := uintptr(size / 4)
 	slice := [3]uintptr{
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*[]EnumerationViewer)(unsafe.Pointer(&slice))
 }
 func (x *ContentViewer) Size(reader *karmem.Reader) (v *ContentSizeViewer) {
-	if 40+4 > x.size() {
+	if 28+4 > x.size() {
 		return (*ContentSizeViewer)(unsafe.Pointer(&_Null))
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 40))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 28))
 	return NewContentSizeViewer(reader, offset)
 }
 func (x *ContentViewer) Name(reader *karmem.Reader) (v string) {
-	if 44+12 > x.size() {
+	if 32+8 > x.size() {
 		return v
 	}
-	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 44))
-	size := *(*uint32)(unsafe.Add(unsafe.Pointer(&x._data), 44+4))
+	offset := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 32))
+	size := *(*uint32)(unsafe.Add(unsafe.Pointer(x), 32+4))
 	if !reader.IsValidOffset(offset, size) {
 		return ""
 	}
@@ -2056,4 +2089,10 @@ func (x *ContentViewer) Name(reader *karmem.Reader) (v string) {
 		uintptr(unsafe.Add(reader.Pointer, offset)), length, length,
 	}
 	return *(*string)(unsafe.Pointer(&slice))
+}
+func (x *ContentViewer) Packed() (v bool) {
+	if 40+1 > x.size() {
+		return v
+	}
+	return *(*bool)(unsafe.Add(unsafe.Pointer(x), 40))
 }

--- a/cmd/karmem/kmparser/testdata/basic.km
+++ b/cmd/karmem/kmparser/testdata/basic.km
@@ -26,6 +26,3 @@ struct User table {
     Locations  [<32]Point;
     AcceptToS  bool;
 }
-
-
-

--- a/cmd/karmem/kmparser/testdata/id.km
+++ b/cmd/karmem/kmparser/testdata/id.km
@@ -1,0 +1,9 @@
+karmem demo @packed();
+
+struct X table @id(123) @expectedId(123) {
+    A uint32;
+}
+
+struct Y table @id(18446744073709551615) @expectedId(18446744073709551615) {
+    A uint32;
+}

--- a/cmd/karmem/kmparser/testdata/packed.km
+++ b/cmd/karmem/kmparser/testdata/packed.km
@@ -1,0 +1,19 @@
+karmem demo @packed();
+
+struct Test inline @total(`5`) @padding(`0`) @content(`5`) {
+    A int32;
+    B int8;
+}
+
+struct TestArray inline @total(`8`) @padding(`0`) @content(`8`) {
+    A []Test;
+}
+
+struct TestOld inline @packed(false) @total(`8`) @padding(`3`) @content(`5`) {
+    A int32;
+    B int8;
+}
+
+struct TestArrayOld inline @packed(false) @total(`16`) @padding(`4`) @content(`12`) {
+    A []Test;
+}

--- a/cmd/karmem/kmparser/testdata/size.km
+++ b/cmd/karmem/kmparser/testdata/size.km
@@ -1,0 +1,261 @@
+karmem demo;
+
+enum UserRegion uint32 {
+    Undefined; Asia; Africa; NorthAmerica; SouthAmerica; Europe; Oceania;
+}
+
+struct AP inline @packed() @total(`4`) @padding(`0`) @content(`4`) {
+    Region UserRegion;
+}
+
+struct AL inline @total(`8`) @padding(`4`) @content(`4`) {
+    Region UserRegion;
+}
+
+struct BP inline @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    String []char;
+}
+
+struct BL inline @total(`16`) @padding(`4`) @content(`12`) {
+    String []char;
+}
+
+struct CP inline @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    X uint64;
+}
+
+struct CL inline @total(`16`) @padding(`8`) @content(`8`) {
+    X uint64;
+}
+
+struct TCP table @packed() @total(`12`) @padding(`0`) @content(`12`) {
+    X uint64;
+}
+
+struct TCL table @total(`12`) @padding(`0`) @content(`12`) {
+    X uint64;
+}
+
+struct DP inline @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    X []uint64;
+}
+
+struct DL inline @total(`16`) @padding(`4`) @content(`12`) {
+    X []uint64;
+}
+
+struct TDP table @packed() @total(`12`) @padding(`0`) @content(`12`) {
+    X []uint64;
+}
+
+struct TDL table @total(`16`) @padding(`0`) @content(`16`) {
+    X []uint64;
+}
+
+struct InlinePacked inline @packed() @total(`2`) @padding(`0`) @content(`2`) {
+    X uint16;
+}
+
+struct InlineOld inline @total(`8`) @padding(`6`) @content(`2`) {
+    X uint16;
+}
+
+struct EP inline @packed() @total(`2`) @padding(`0`) @content(`2`) {
+    X InlinePacked;
+}
+
+struct EL inline @total(`8`) @padding(`6`) @content(`2`) {
+    X InlinePacked;
+}
+
+struct TEP table @packed() @total(`6`) @padding(`0`) @content(`6`) {
+    X InlinePacked;
+}
+
+struct TEL table @total(`6`) @padding(`0`) @content(`6`) {
+    X InlinePacked;
+}
+
+struct LEP inline @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    X InlineOld;
+}
+
+struct LEL inline @total(`16`) @padding(`8`) @content(`8`) {
+    X InlineOld;
+}
+
+struct LTEP table @packed() @total(`12`) @padding(`0`) @content(`12`) {
+    X InlineOld;
+}
+
+struct LTEL table @total(`12`) @padding(`0`) @content(`12`) {
+    X InlineOld;
+}
+
+struct TablePacked table @packed() @total(`6`) @padding(`0`) @content(`6`) {
+    X uint16;
+}
+
+struct TableOld table @total(`6`) @padding(`0`) @content(`6`) {
+    X uint16;
+}
+
+struct FP inline @packed() @total(`4`) @padding(`0`) @content(`4`) {
+    X TablePacked;
+}
+
+struct FL inline @total(`8`) @padding(`4`) @content(`4`) {
+    X TablePacked;
+}
+
+struct FFP inline @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    X TablePacked;
+    Y TablePacked;
+}
+
+struct FFL inline @total(`16`) @padding(`8`) @content(`8`) {
+    X TablePacked;
+    Y TablePacked;
+}
+
+struct TFFP table @packed() @total(`12`) @padding(`0`) @content(`12`) {
+    X TablePacked;
+    Y TablePacked;
+}
+
+struct TFFL table @total(`12`) @padding(`0`) @content(`12`) {
+    X TablePacked;
+    Y TablePacked;
+}
+
+struct TFP table @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    X TablePacked;
+}
+
+struct TFL table @total(`8`) @padding(`0`) @content(`8`) {
+    X TablePacked;
+}
+
+struct GP inline @packed() @total(`4`) @padding(`0`) @content(`4`) {
+    X TableOld;
+}
+
+struct GL table @total(`8`) @padding(`0`) @content(`8`) {
+    X TableOld;
+}
+
+struct GGL inline @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    X TableOld;
+    Y TableOld;
+}
+
+struct GGP inline @total(`16`) @padding(`8`) @content(`8`) {
+    X TableOld;
+    Y TableOld;
+}
+
+struct OGGL table @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    X TableOld;
+}
+
+struct OGGP table @total(`8`) @padding(`0`) @content(`8`) {
+    X TableOld;
+}
+
+struct TGGL table @packed() @total(`12`) @padding(`0`) @content(`12`) {
+    X TableOld;
+    Y TableOld;
+}
+
+struct TGGP table @total(`12`) @padding(`0`) @content(`12`) {
+    X TableOld;
+    Y TableOld;
+}
+
+struct InlineArrayPacked inline @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    Array []uint32;
+}
+
+struct IJP inline @packed() @total(`8`) @padding(`0`) @content(`8`) {
+    X InlineArrayPacked;
+}
+
+struct IJL inline @total(`16`) @padding(`8`) @content(`8`) {
+    X InlineArrayPacked;
+}
+
+struct TIJP table @packed() @total(`12`) @padding(`0`) @content(`12`) {
+    X InlineArrayPacked;
+}
+
+struct TIJL table @total(`12`) @padding(`0`) @content(`12`) {
+    X InlineArrayPacked;
+}
+
+struct InlineArrayOld inline @total(`16`) @padding(`4`) @content(`12`) {
+    Array []uint32;
+}
+
+struct ILP inline @packed() @total(`16`) @padding(`0`) @content(`16`) {
+    X InlineArrayOld;
+}
+
+struct ILL inline @total(`24`) @padding(`8`) @content(`16`) {
+    X InlineArrayOld;
+}
+
+struct TILP table @packed() @total(`20`) @padding(`0`) @content(`20`) {
+    X InlineArrayOld;
+}
+
+struct TILL table @total(`20`) @padding(`0`) @content(`20`) {
+    X InlineArrayOld;
+}
+
+struct IHP inline @packed() @total(`19`) @padding(`0`) @content(`19`) {
+    A uint16;
+    B uint32;
+    C uint32;
+    D uint8;
+    E []uint8;
+}
+
+struct IHL inline @total(`24`) @padding(`1`) @content(`23`) {
+    A uint16;
+    B uint32;
+    C uint32;
+    D uint8;
+    E []uint8;
+}
+
+struct IHXP inline @packed() @total(`19`) @padding(`0`) @content(`19`) {
+    A uint16;
+    B uint32;
+    C uint32;
+    D uint8;
+    E InlineArrayPacked;
+}
+
+struct IHXL inline @total(`24`) @padding(`5`) @content(`19`) {
+    A uint16;
+    B uint32;
+    C uint32;
+    D uint8;
+    E InlineArrayPacked;
+}
+
+struct IHZP inline @packed() @total(`27`) @padding(`0`) @content(`27`) {
+    A uint16;
+    B uint32;
+    C uint32;
+    D uint8;
+    E InlineArrayOld;
+}
+
+struct IHZL inline @total(`32`) @padding(`5`) @content(`27`) {
+    A uint16;
+    B uint32;
+    C uint32;
+    D uint8;
+    E InlineArrayOld;
+}


### PR DESCRIPTION
Now, it's possible (and recommended) to use `@packed()` to produce
smaller encoded data. Additionally, `table` will use `@packed()` by
default, and that is backward-compatible.

That change also removes the `size-each` value from slice-headers,
which saves 4-bytes per each dynamic array.

This tag can be use in the project header, enabling it on all
`inline` struct declared in the file:
```
karmem name @packed();
```

This tag can be used to enable/disable `@packed()` for each
`inline`:

```
struct Foo inline @packed(true) { ... }
```

If the document is using `@packed(true)`, it's possible to opt-out,
using `@packed(false)` for specific struct:

```
struct Foo inline @packed(false) { ... }
```

There's no reason to use `@packed(false)`, except from compatibility
reasons, for projects releases before this patch.

Closes #71
Closes #65
Fixes #32

Signed-off-by: Inkeliz <inkeliz@inkeliz.com>