### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/flatbuffers v2.0.6+incompatible
 	github.com/google/gofuzz v1.2.0
 	github.com/r3labs/diff/v3 v3.0.0
-	github.com/tetratelabs/wazero v1.0.0-beta.2
+	github.com/tetratelabs/wazero v1.0.0-pre.3
 	golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9
 	golang.org/x/text v0.3.7
 	karmem.org v1.0.0

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -14,8 +14,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v1.0.0-beta.2 h1:Qa1R1oizAYHcmy8PljgINdXUZ/nRQkxUBbYfGSb4IBE=
-github.com/tetratelabs/wazero v1.0.0-beta.2/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/benchmark/main_wasi_wazero.go
+++ b/benchmark/main_wasi_wazero.go
@@ -6,10 +6,11 @@ package main
 import (
 	"context"
 	"errors"
-	"github.com/tetratelabs/wazero/imports/assemblyscript"
-	"github.com/tetratelabs/wazero/imports/emscripten"
 	"os"
 	"path/filepath"
+
+	"github.com/tetratelabs/wazero/imports/assemblyscript"
+	"github.com/tetratelabs/wazero/imports/emscripten"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
@@ -19,7 +20,8 @@ import (
 func initBridge(b interface {
 	Error(...any)
 	Fatal(...any)
-}, fn ...string) Bridge {
+}, fn ...string,
+) Bridge {
 	w := &WasmWazero{}
 	var err error
 	w.runtime = wazero.NewRuntime(context.Background())

--- a/benchmark/main_wasi_wazero.go
+++ b/benchmark/main_wasi_wazero.go
@@ -6,14 +6,14 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
+	"github.com/tetratelabs/wazero/imports/assemblyscript"
+	"github.com/tetratelabs/wazero/imports/emscripten"
 	"os"
 	"path/filepath"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
-	"golang.org/x/text/encoding/unicode"
 )
 
 func initBridge(b interface {
@@ -22,7 +22,7 @@ func initBridge(b interface {
 }, fn ...string) Bridge {
 	w := &WasmWazero{}
 	var err error
-	w.runtime = wazero.NewRuntimeWithConfig(context.Background(), wazero.NewRuntimeConfigCompiler().WithWasmCore2())
+	w.runtime = wazero.NewRuntime(context.Background())
 
 	_, err = wasi_snapshot_preview1.Instantiate(context.Background(), w.runtime)
 	if err != nil {
@@ -31,33 +31,10 @@ func initBridge(b interface {
 
 	config := wazero.NewModuleConfig().WithStdout(os.Stdout).WithStderr(os.Stdout)
 
-	getStringImpl := func(ptr int32) string {
-		len, _ := w.mainModule.Memory().ReadUint32Le(nil, uint32(ptr+(-4)))
-		wtf16, _ := w.mainModule.Memory().Read(nil, uint32(ptr), len)
-
-		b, err := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder().Bytes(wtf16)
-		if err != nil {
-			panic(err)
-		}
-		return string(b)
-	}
-
-	__getString := func(ptr int32) string {
-		return getStringImpl(ptr)
-	}
-
-	_, err = w.runtime.NewModuleBuilder("env").
-		ExportFunction("abort", func(msg, file, line, column int32) {
-			var m string
-			m += fmt.Sprint(`msg:`, __getString(msg))
-			m += fmt.Sprint(`file:`, __getString(file))
-			m += fmt.Sprint(`line:`, __getString(line))
-			m += fmt.Sprint(`column:`, __getString(column))
-			panic(m)
-		}).
-		ExportFunction("emscripten_notify_memory_growth", func(_ int32) {
-		}).
-		Instantiate(context.Background(), w.runtime)
+	envBuilder := w.runtime.NewHostModuleBuilder("env")
+	emscripten.NewFunctionExporter().ExportFunctions(envBuilder)
+	assemblyscript.NewFunctionExporter().ExportFunctions(envBuilder)
+	_, err = envBuilder.Instantiate(context.Background(), w.runtime)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -67,7 +44,7 @@ func initBridge(b interface {
 		b.Fatal(err)
 	}
 
-	compiledWasi, err := w.runtime.CompileModule(context.Background(), wasifile, wazero.NewCompileConfig())
+	compiledWasi, err := w.runtime.CompileModule(context.Background(), wasifile)
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). Note: wazero 1.0 will require Go 1.18+

Notably, this improves performance and changes host function syntax.