### PR TITLE
[go] fix a wrong generation when field is  "[]char" type

### DIFF
--- a/cmd/karmem/kmgen/golang_template.gotmpl
+++ b/cmd/karmem/kmgen/golang_template.gotmpl
@@ -182,7 +182,7 @@
                     x.{{$field.Data.Name}}.Read(viewer.{{$field.Data.Name}}(reader), reader)
                 {{- end}}
                 {{- if $field.Data.Type.IsString}}
-                    __{{$field.Data.Name}}String := viewer.{{$field.Data.Name}}(reader)
+                    __{{$field.Data.Name}}String := viewer.{{$field.Data.Name}}({{- if not $field.Data.Type.IsInline}}reader{{- end}})
                     if x.{{$field.Data.Name}} != __{{$field.Data.Name}}String {
                     __{{$field.Data.Name}}StringCopy := make([]byte, len(__{{$field.Data.Name}}String))
                     copy(__{{$field.Data.Name}}StringCopy, __{{$field.Data.Name}}String)


### PR DESCRIPTION
generated code with superfluous parameter.
![image](https://github.com/user-attachments/assets/517df2fd-00b6-45b0-bedc-380ed5a539e4)
